### PR TITLE
Add dirty flag to string resources and request translating strings only for dirty strings by default

### DIFF
--- a/core/model/src/commonMain/kotlin/io/composeflow/model/project/string/StringResource.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/project/string/StringResource.kt
@@ -18,7 +18,7 @@ data class StringResource(
     val description: String? = null,
     @Serializable(with = FallbackMutableStateMapSerializer::class)
     val localizedValues: MutableMap<ResourceLocale, String> = mutableStateMapEqualsOverrideOf(),
-    /** 
+    /**
      * Tracks whether the default locale value has been updated since the last translation.
      * This helps identify which strings need re-translation.
      */

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/project/string/StringResource.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/project/string/StringResource.kt
@@ -18,6 +18,11 @@ data class StringResource(
     val description: String? = null,
     @Serializable(with = FallbackMutableStateMapSerializer::class)
     val localizedValues: MutableMap<ResourceLocale, String> = mutableStateMapEqualsOverrideOf(),
+    /** 
+     * Tracks whether the default locale value has been updated since the last translation.
+     * This helps identify which strings need re-translation.
+     */
+    val needsTranslationUpdate: Boolean = false,
 )
 
 @JvmName("stringResourceOfWithLocale")

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/project/string/StringResourceHolder.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/project/string/StringResourceHolder.kt
@@ -112,3 +112,10 @@ fun StringResourceHolder.copyContents(other: StringResourceHolder) {
     supportedLocales.clear()
     supportedLocales.addAll(other.supportedLocales)
 }
+
+/**
+ * Returns true if the StringResourceHolder has multiple locales,
+ * indicating that string resources are translatable.
+ */
+val StringResourceHolder.isTranslatable: Boolean
+    get() = supportedLocales.any { it != defaultLocale.value }

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -535,6 +535,7 @@ instead of in the canvas.</string>
     <string name="string_resources">String Resources</string>
     <string name="translate_strings">Translate strings</string>
     <string name="translating_strings">Translating strings...</string>
+    <string name="needs_translation_update">This string may need translation update.</string>
 
     <!-- Locale display names -->
     <string name="locale_name_af">Afrikaans</string>

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -533,8 +533,10 @@ instead of in the canvas.</string>
     <string name="string_resource_key_placeholder">Resource key</string>
     <string name="string_resource_key_tooltip">The unique identifier for this string resource, used to reference it in UI and other resources.</string>
     <string name="string_resources">String Resources</string>
-    <string name="translate_strings">Translate strings</string>
+    <string name="translate_selected_strings">Translate selected strings</string>
     <string name="translating_strings">Translating strings...</string>
+    <string name="update_translations">Update translations</string>
+    <string name="updating_translations">Updating translations...</string>
     <string name="needs_translation_update">This string may need translation update.</string>
 
     <!-- Locale display names -->

--- a/feature/string-editor/src/commonMain/kotlin/io/composeflow/ui/string/StringResourceEditorScreen.kt
+++ b/feature/string-editor/src/commonMain/kotlin/io/composeflow/ui/string/StringResourceEditorScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material.icons.outlined.Sync
 import androidx.compose.material.icons.outlined.Translate
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
@@ -95,6 +96,7 @@ import io.composeflow.model.project.Project
 import io.composeflow.model.project.string.ResourceLocale
 import io.composeflow.model.project.string.StringResource
 import io.composeflow.more_options
+import io.composeflow.needs_translation_update
 import io.composeflow.no_locales_found_matching
 import io.composeflow.remove
 import io.composeflow.remove_locale
@@ -607,16 +609,27 @@ private fun StringResourceTableDataRow(
                 )
             }
             VerticalDivider()
-            Box(
-                modifier = Modifier.width(keyColumnWidth).fillMaxHeight(),
-                contentAlignment = Alignment.CenterStart,
+            Row(
+                modifier = Modifier.width(keyColumnWidth).fillMaxHeight().padding(4.dp),
             ) {
                 CellEditableText(
                     initialText = resource.key,
                     onValueChange = onUpdateKey,
                     textStyle = MaterialTheme.typography.bodyLarge.copy(color = MaterialTheme.colorScheme.onSurface),
-                    modifier = Modifier.fillMaxWidth().padding(4.dp),
+                    modifier = Modifier.align(Alignment.CenterVertically).weight(1f),
                 )
+                if (resource.needsTranslationUpdate) {
+                    Tooltip(
+                        text = stringResource(Res.string.needs_translation_update),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Outlined.Sync,
+                            contentDescription = stringResource(Res.string.needs_translation_update),
+                            tint = MaterialTheme.colorScheme.tertiary,
+                            modifier = Modifier.size(12.dp),
+                        )
+                    }
+                }
             }
             ColumnDivider()
             Box(

--- a/feature/string-editor/src/commonMain/kotlin/io/composeflow/ui/string/StringResourceEditorScreen.kt
+++ b/feature/string-editor/src/commonMain/kotlin/io/composeflow/ui/string/StringResourceEditorScreen.kt
@@ -258,7 +258,7 @@ private fun StringResourceEditorContent(
                             isTranslating = isTranslating,
                         )
                     } else {
-                        // Show disabled "Translate Strings" button when nothing to translate
+                        // Show disabled "Update Translations" button when nothing to translate
                         UpdateTranslationsButton(
                             onClick = { },
                             enabled = false,

--- a/feature/string-editor/src/commonMain/kotlin/io/composeflow/ui/string/StringResourceEditorViewModel.kt
+++ b/feature/string-editor/src/commonMain/kotlin/io/composeflow/ui/string/StringResourceEditorViewModel.kt
@@ -166,7 +166,12 @@ class StringResourceEditorViewModel(
                                         updatedLocalizedValues[locale] = translation
                                     }
                                 }
-                                val updatedResource = resource.copy(localizedValues = updatedLocalizedValues)
+                                val updatedResource =
+                                    resource.copy(
+                                        localizedValues = updatedLocalizedValues,
+                                        // Clear the flag after successful translation
+                                        needsTranslationUpdate = false,
+                                    )
                                 // TODO Support bulk update of string resources
                                 //      https://github.com/ComposeFlow/ComposeFlow/issues/41
                                 stringResourceEditorOperator.updateStringResource(project, updatedResource)

--- a/feature/string-editor/src/commonMain/kotlin/io/composeflow/ui/string/StringResourceEditorViewModel.kt
+++ b/feature/string-editor/src/commonMain/kotlin/io/composeflow/ui/string/StringResourceEditorViewModel.kt
@@ -130,13 +130,25 @@ class StringResourceEditorViewModel(
         selectedResourceIds.clear()
     }
 
+    fun onTranslateNeedsUpdateStrings() {
+        val resourcesToTranslate = project.stringResourceHolder.stringResources.filter { it.needsTranslationUpdate }
+        if (resourcesToTranslate.isEmpty()) {
+            Logger.e("No resources need translation updates. Button should be disabled")
+            return
+        }
+        translateResourcesInternal(resourcesToTranslate)
+    }
+
     fun onTranslateStrings() {
         val selectedResources = project.stringResourceHolder.stringResources.filter { selectedResourceIds.contains(it.id) }
         if (selectedResources.isEmpty()) {
             Logger.e("No valid resources selected for translation. Translate button should be disabled")
             return
         }
+        translateResourcesInternal(selectedResources)
+    }
 
+    private fun translateResourcesInternal(resourcesToTranslate: List<StringResource>) {
         val defaultLocale = project.stringResourceHolder.defaultLocale.value
         val targetLocales = project.stringResourceHolder.supportedLocales.filter { it != defaultLocale }
         if (targetLocales.isEmpty()) {
@@ -150,13 +162,13 @@ class StringResourceEditorViewModel(
                 val result =
                     llmRepository.translateStrings(
                         firebaseIdToken = firebaseIdToken.rawToken ?: throw IllegalStateException("Signed-in user has no raw token"),
-                        stringResources = selectedResources,
+                        stringResources = resourcesToTranslate,
                         defaultLocale = defaultLocale,
                         targetLocales = targetLocales,
                     )
                 when (result) {
                     is TranslateStringsResult.Success -> {
-                        selectedResources.forEach { resource ->
+                        resourcesToTranslate.forEach { resource ->
                             val translationsForResource = result.translations[resource.key]
                             if (translationsForResource != null) {
                                 val updatedLocalizedValues = resource.localizedValues.toMutableStateMapEqualsOverride()


### PR DESCRIPTION
Close #35.

Introduced `needsTranslationUpdate` flag for each `StringResource` (445dfb01986192c90974bd5f23d65cb047aa8bf9). The flag for each string is set when its default locale value or description is updated. Also the flags of the all strings are asserted when new locales are added or the default locale is changed.

When there are dirty strings, show "Update translations" button instead of "Translate selected strings" button, and translate only the flagged strings with LLM API when the button is clicked.

https://github.com/user-attachments/assets/2f0dab22-dec1-4541-bf4f-3e36dfa42544
