### PR TITLE
Fix KSP task type configuration to disable output cache

### DIFF
--- a/feature/appstate-editor/build.gradle.kts
+++ b/feature/appstate-editor/build.gradle.kts
@@ -69,7 +69,7 @@ tasks.register("runKsp") {
 
 // Make sure the KSP tasks run
 afterEvaluate {
-    tasks.withType<com.google.devtools.ksp.gradle.KspTask>().configureEach {
+    tasks.withType<com.google.devtools.ksp.gradle.KspAATask>().configureEach {
         // Ensure the KSP task runs
         outputs.upToDateWhen { false }
     }

--- a/feature/appstate-editor/build.gradle.kts
+++ b/feature/appstate-editor/build.gradle.kts
@@ -35,7 +35,7 @@ kotlin {
         // Configure KSP options
         ksp {
             // Set output directory for LLM tool JSON files
-            arg("llmToolsOutputDir", "${project.buildDir}/generated/llm-tools")
+            arg("llmToolsOutputDir", "${project.layout.buildDirectory}/generated/llm-tools")
         }
 
         commonTest.dependencies {
@@ -60,7 +60,7 @@ tasks.register("runKsp") {
 
     // Create the output directory
     doFirst {
-        mkdir("${project.buildDir}/generated/llm-tools")
+        mkdir("${project.layout.buildDirectory}/generated/llm-tools")
     }
 
     // Depend on the KSP task for the JVM target

--- a/feature/datatype-editor/build.gradle.kts
+++ b/feature/datatype-editor/build.gradle.kts
@@ -38,7 +38,7 @@ kotlin {
         // Configure KSP options
         ksp {
             // Set output directory for LLM tool JSON files
-            arg("llmToolsOutputDir", "${project.buildDir}/generated/llm-tools")
+            arg("llmToolsOutputDir", "${project.layout.buildDirectory}/generated/llm-tools")
         }
 
         commonTest.dependencies {
@@ -63,7 +63,7 @@ tasks.register("runKsp") {
 
     // Create the output directory
     doFirst {
-        mkdir("${project.buildDir}/generated/llm-tools")
+        mkdir("${project.layout.buildDirectory}/generated/llm-tools")
     }
 
     // Depend on the KSP task for the JVM target

--- a/feature/datatype-editor/build.gradle.kts
+++ b/feature/datatype-editor/build.gradle.kts
@@ -72,7 +72,7 @@ tasks.register("runKsp") {
 
 // Make sure the KSP tasks run
 afterEvaluate {
-    tasks.withType<com.google.devtools.ksp.gradle.KspTask>().configureEach {
+    tasks.withType<com.google.devtools.ksp.gradle.KspAATask>().configureEach {
         // Ensure the KSP task runs
         outputs.upToDateWhen { false }
     }

--- a/feature/string-editor/build.gradle.kts
+++ b/feature/string-editor/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
         // Configure KSP options
         ksp {
             // Set output directory for LLM tool JSON files
-            arg("llmToolsOutputDir", "${project.buildDir}/generated/llm-tools")
+            arg("llmToolsOutputDir", "${project.layout.buildDirectory}/generated/llm-tools")
         }
 
         commonTest.dependencies {
@@ -63,7 +63,7 @@ tasks.register("runKsp") {
 
     // Create the output directory
     doFirst {
-        mkdir("${project.buildDir}/generated/llm-tools")
+        mkdir("${project.layout.buildDirectory}/generated/llm-tools")
     }
 
     // Depend on the KSP task for the JVM target

--- a/feature/string-editor/build.gradle.kts
+++ b/feature/string-editor/build.gradle.kts
@@ -72,7 +72,7 @@ tasks.register("runKsp") {
 
 // Make sure the KSP tasks run
 afterEvaluate {
-    tasks.withType<com.google.devtools.ksp.gradle.KspTask>().configureEach {
+    tasks.withType<com.google.devtools.ksp.gradle.KspAATask>().configureEach {
         // Ensure the KSP task runs
         outputs.upToDateWhen { false }
     }

--- a/feature/uibuilder/build.gradle.kts
+++ b/feature/uibuilder/build.gradle.kts
@@ -61,7 +61,7 @@ kotlin {
         // Configure KSP options
         ksp {
             // Set output directory for LLM tool JSON files
-            arg("llmToolsOutputDir", "${project.buildDir}/generated/llm-tools")
+            arg("llmToolsOutputDir", "${project.layout.buildDirectory}/generated/llm-tools")
         }
         named("jvmMain") {
             dependencies {
@@ -90,7 +90,7 @@ tasks.register("runKsp") {
 
     // Create the output directory
     doFirst {
-        mkdir("${project.buildDir}/generated/llm-tools")
+        mkdir("${project.layout.buildDirectory}/generated/llm-tools")
     }
 
     // Depend on the KSP task for the JVM target

--- a/feature/uibuilder/build.gradle.kts
+++ b/feature/uibuilder/build.gradle.kts
@@ -99,7 +99,7 @@ tasks.register("runKsp") {
 
 // Make sure the KSP tasks run
 afterEvaluate {
-    tasks.withType<com.google.devtools.ksp.gradle.KspTask>().configureEach {
+    tasks.withType<com.google.devtools.ksp.gradle.KspAATask>().configureEach {
         // Ensure the KSP task runs
         outputs.upToDateWhen { false }
     }

--- a/ksp-llm-tools/build.gradle.kts
+++ b/ksp-llm-tools/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 
 // Configure KSP options
 ksp {
-    arg("llmToolsOutputDir", "${project.buildDir}/generated/llm-tools")
+    arg("llmToolsOutputDir", "${project.layout.buildDirectory}/generated/llm-tools")
 }
 
 // Configure Kotlin compiler options
@@ -52,7 +52,7 @@ tasks.register("runExample") {
 
     // Create a directory for the example output
     doFirst {
-        mkdir("${project.buildDir}/generated/llm-tools")
+        mkdir("${project.layout.buildDirectory}/generated/llm-tools")
     }
 
     // Depend on the run task


### PR DESCRIPTION
Close #102.

### Issue

It seems the task type of `kspKotlinJvm` is `KspAATask` which doesn't implement `KspTask` interface. The configuration for `outputs.upToDateWhen` was not applied to `kspKotlinJvm` and the task is skipped when `generate_mcp_schemas.sh` is executed.

### Solution

Use `KspAATask` to configure `outputs.upToDateWhen` b99842cc5addd029fa1b9de5b9dbbb6eccdfae64.

### Additional change

Since `project.buildDir` is deprecated, replaced it with `project.layout.buildDirectory` fd3f466b8cef5a080eae3241442bacb2db18b3da.