### PR TITLE
Replace custom NavigationRail with Jetpack Compose NavigationRail (WASM compatible)

### DIFF
--- a/core/model/src/commonMain/kotlin/io/composeflow/custom/composeflowicons/TranslateDark.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/custom/composeflowicons/TranslateDark.kt
@@ -1,0 +1,73 @@
+package io.composeflow.custom.composeflowicons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import io.composeflow.custom.ComposeFlowIcons
+
+val ComposeFlowIcons.TranslateDark: ImageVector
+    get() {
+        if (_TranslateDark != null) {
+            return _TranslateDark!!
+        }
+        _TranslateDark =
+            ImageVector
+                .Builder(
+                    name = "TranslateDark",
+                    defaultWidth = 20.dp,
+                    defaultHeight = 20.dp,
+                    viewportWidth = 960f,
+                    viewportHeight = 960f,
+                ).apply {
+                    path(fill = SolidColor(Color(0xFFCED0D6))) {
+                        moveToRelative(488f, 864f)
+                        lineToRelative(171f, -456f)
+                        horizontalLineToRelative(82f)
+                        lineTo(912f, 864f)
+                        horizontalLineToRelative(-79f)
+                        lineToRelative(-41f, -117f)
+                        lineTo(608f, 747f)
+                        lineTo(567f, 864f)
+                        horizontalLineToRelative(-79f)
+                        close()
+                        moveTo(169f, 744f)
+                        lineToRelative(-50f, -51f)
+                        lineToRelative(192f, -190f)
+                        quadToRelative(-36f, -38f, -67f, -79f)
+                        reflectiveQuadToRelative(-54f, -89f)
+                        horizontalLineToRelative(82f)
+                        quadToRelative(18f, 32f, 36f, 54.5f)
+                        reflectiveQuadToRelative(52f, 60.5f)
+                        quadToRelative(38f, -42f, 70f, -87.5f)
+                        reflectiveQuadToRelative(52f, -98.5f)
+                        lineTo(48f, 264f)
+                        verticalLineToRelative(-72f)
+                        horizontalLineToRelative(276f)
+                        verticalLineToRelative(-96f)
+                        horizontalLineToRelative(72f)
+                        verticalLineToRelative(96f)
+                        horizontalLineToRelative(276f)
+                        verticalLineToRelative(72f)
+                        lineTo(558f, 264f)
+                        quadToRelative(-21f, 69f, -61f, 127.5f)
+                        reflectiveQuadTo(409f, 503f)
+                        lineToRelative(91f, 90f)
+                        lineToRelative(-28f, 74f)
+                        lineToRelative(-112f, -112f)
+                        lineToRelative(-191f, 189f)
+                        close()
+                        moveTo(632f, 681f)
+                        horizontalLineToRelative(136f)
+                        lineToRelative(-66f, -189f)
+                        lineToRelative(-70f, 189f)
+                        close()
+                    }
+                }.build()
+
+        return _TranslateDark!!
+    }
+
+@Suppress("ObjectPropertyName")
+private var _TranslateDark: ImageVector? = null

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/TopLevelDestination.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/TopLevelDestination.kt
@@ -5,6 +5,16 @@ import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.FlashOn
 import androidx.compose.material.icons.outlined.ZoomIn
 import androidx.compose.ui.graphics.vector.ImageVector
+import io.composeflow.custom.ComposeFlowIcons
+import io.composeflow.custom.composeflowicons.AssetsDark
+import io.composeflow.custom.composeflowicons.CloudFirestore
+import io.composeflow.custom.composeflowicons.Colors
+import io.composeflow.custom.composeflowicons.DatacolumnDark
+import io.composeflow.custom.composeflowicons.DbmsDark
+import io.composeflow.custom.composeflowicons.EditfolderDark
+import io.composeflow.custom.composeflowicons.HttpRequestsFiletypeDark
+import io.composeflow.custom.composeflowicons.SettingsDark
+import io.composeflow.custom.composeflowicons.TranslateDark
 
 const val UI_BUILDER_ROUTE = "ui_builder_route"
 const val DATA_TYPE_EDITOR_ROUTE = "datatype_editor_route"
@@ -17,52 +27,52 @@ const val STRING_EDITOR_ROUTE = "string_editor_route"
 const val SETTINGS_ROUTE = "settings_route"
 
 enum class TopLevelDestination(
-    val iconPath: String,
+    val icon: ImageVector,
     val label: String,
     val route: String,
 ) {
     UiBuilder(
-        "icons/editFolder.svg",
+        ComposeFlowIcons.EditfolderDark,
         "UI Builder",
         UI_BUILDER_ROUTE,
     ),
     DataTypeEditor(
-        "icons/dataColumn.svg",
+        ComposeFlowIcons.DatacolumnDark,
         "Data type",
         DATA_TYPE_EDITOR_ROUTE,
     ),
     AppStateEditor(
-        "icons/dbms.svg",
+        ComposeFlowIcons.DbmsDark,
         "App State",
         APP_STATE_EDITOR_ROUTE,
     ),
     FirestoreEditor(
-        "icons/cloud_firestore.svg",
+        ComposeFlowIcons.CloudFirestore,
         "Firestore",
         FIRESTORE_EDITOR_ROUTE,
     ),
     ApiEditor(
-        "icons/http_requests_filetype.svg",
+        ComposeFlowIcons.HttpRequestsFiletypeDark,
         "API editor",
         API_EDITOR_ROUTE,
     ),
     ThemeEditor(
-        "icons/colors.svg",
+        ComposeFlowIcons.Colors,
         "Theme editor",
         THEME_EDITOR_ROUTE,
     ),
     AssetEditor(
-        "icons/assets.svg",
+        ComposeFlowIcons.AssetsDark,
         "Assets",
         ASSET_EDITOR_ROUTE,
     ),
     StringEditor(
-        "icons/translate.svg",
+        ComposeFlowIcons.TranslateDark,
         "Strings",
         STRING_EDITOR_ROUTE,
     ),
     Settings(
-        "icons/settings.svg",
+        ComposeFlowIcons.SettingsDark,
         "Settings",
         SETTINGS_ROUTE,
     ),

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ProjectEditorView.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ProjectEditorView.kt
@@ -1,30 +1,19 @@
 package io.composeflow
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.NavigationRail
-import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.Surface
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
@@ -39,18 +28,14 @@ import io.composeflow.ai.AiChatDialog
 import io.composeflow.auth.LocalFirebaseIdToken
 import io.composeflow.auth.isAiEnabled
 import io.composeflow.model.ProvideNavigator
-import io.composeflow.model.TopLevelDestination
-import io.composeflow.ui.Tooltip
 import io.composeflow.ui.jewel.TitleBarContent
+import io.composeflow.ui.navigationrail.LeftNavigationRail
 import io.composeflow.ui.statusbar.StatusBar
 import io.composeflow.ui.statusbar.StatusBarViewModel
 import io.composeflow.ui.toolbar.LeftToolbar
 import io.composeflow.ui.toolbar.RightToolbar
-import moe.tlaster.precompose.navigation.NavOptions
-import moe.tlaster.precompose.navigation.PopUpTo
 import moe.tlaster.precompose.navigation.rememberNavigator
 import moe.tlaster.precompose.viewmodel.viewModel
-import org.jetbrains.jewel.ui.component.Icon
 
 const val MAIN_VIEW_TEST_TAG = "MainView"
 
@@ -92,15 +77,6 @@ fun ProjectEditorContent(
     val aiAssistantUiState by viewModel.aiAssistantUiState.collectAsState()
 
     val projectEditorNavigator = rememberNavigator()
-    val currentDestination =
-        TopLevelDestination.entries.firstOrNull {
-            it.route ==
-                projectEditorNavigator.currentEntry
-                    .collectAsState(null)
-                    .value
-                    ?.route
-                    ?.route
-        }
     val showAiChatDialog = viewModel.showAiChatDialog.collectAsState().value
     val aiChatToggleVisibilityModifier =
         if (isAiEnabled) {
@@ -147,59 +123,9 @@ fun ProjectEditorContent(
                     }
 
                     Row(modifier = Modifier.weight(1f).fillMaxWidth()) {
-                        var selectedItem by remember(currentDestination) {
-                            mutableStateOf(
-                                currentDestination?.ordinal ?: 0,
-                            )
-                        }
-                        NavigationRail(
-                            modifier = Modifier.width(40.dp).fillMaxHeight(),
-                        ) {
-                            TopLevelDestination.entries.forEachIndexed { index, item ->
-                                @Suppress("KotlinConstantConditions")
-                                if (BuildConfig.isRelease) {
-                                    if (item == TopLevelDestination.StringEditor) {
-                                        return@forEachIndexed
-                                    }
-                                }
-                                Tooltip(item.label) {
-                                    NavigationRailItem(
-                                        modifier =
-                                            Modifier
-                                                .size(40.dp)
-                                                .padding(5.dp)
-                                                .clip(MaterialTheme.shapes.extraSmall)
-                                                .testTag("$NAVIGATION_RAIL_TEST_TAG/${item.name}"),
-                                        selected = selectedItem == item.ordinal,
-                                        onClick = {
-                                            projectEditorNavigator.navigate(
-                                                item.route,
-                                                options =
-                                                    NavOptions(
-                                                        popUpTo =
-                                                            PopUpTo(
-                                                                route = item.route,
-                                                            ),
-                                                    ),
-                                            )
-                                            selectedItem = index
-                                        },
-                                        icon = {
-                                            Box(
-                                                modifier = Modifier.fillMaxSize(),
-                                                contentAlignment = Alignment.Center,
-                                            ) {
-                                                Icon(
-                                                    modifier = Modifier.size(20.dp),
-                                                    imageVector = item.icon,
-                                                    contentDescription = "icon",
-                                                )
-                                            }
-                                        },
-                                    )
-                                }
-                            }
-                        }
+                        LeftNavigationRail(
+                            navigator = projectEditorNavigator,
+                        )
                         VerticalDivider(
                             color = MaterialTheme.colorScheme.surfaceContainerHigh,
                             modifier =

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ProjectEditorView.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ProjectEditorView.kt
@@ -1,17 +1,19 @@
 package io.composeflow
 
-import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.Surface
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
@@ -20,7 +22,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
@@ -47,10 +51,6 @@ import moe.tlaster.precompose.navigation.PopUpTo
 import moe.tlaster.precompose.navigation.rememberNavigator
 import moe.tlaster.precompose.viewmodel.viewModel
 import org.jetbrains.jewel.ui.component.Icon
-import org.jetbrains.jewel.ui.component.SelectableIconButton
-import org.jetbrains.jewel.ui.component.styling.LocalIconButtonStyle
-import org.jetbrains.jewel.ui.painter.hints.Stroke
-import org.jetbrains.jewel.ui.painter.rememberResourcePainterProvider
 
 const val MAIN_VIEW_TEST_TAG = "MainView"
 
@@ -105,10 +105,7 @@ fun ProjectEditorContent(
     val aiChatToggleVisibilityModifier =
         if (isAiEnabled) {
             Modifier.onPreviewKeyEvent { event ->
-                if (event.type == KeyEventType.KeyDown &&
-                    event.key == Key.K &&
-                    (event.isMetaPressed || event.isCtrlPressed)
-                ) {
+                if (event.type == KeyEventType.KeyDown && event.key == Key.K && (event.isMetaPressed || event.isCtrlPressed)) {
                     viewModel.onToggleShowAiChatDialog()
                     true
                 } else {
@@ -155,12 +152,8 @@ fun ProjectEditorContent(
                                 currentDestination?.ordinal ?: 0,
                             )
                         }
-                        Column(
-                            modifier =
-                                Modifier
-                                    .width(40.dp)
-                                    .fillMaxHeight()
-                                    .background(color = MaterialTheme.colorScheme.surface),
+                        NavigationRail(
+                            modifier = Modifier.width(40.dp).fillMaxHeight(),
                         ) {
                             TopLevelDestination.entries.forEachIndexed { index, item ->
                                 @Suppress("KotlinConstantConditions")
@@ -170,7 +163,13 @@ fun ProjectEditorContent(
                                     }
                                 }
                                 Tooltip(item.label) {
-                                    SelectableIconButton(
+                                    NavigationRailItem(
+                                        modifier =
+                                            Modifier
+                                                .size(40.dp)
+                                                .padding(5.dp)
+                                                .clip(MaterialTheme.shapes.extraSmall)
+                                                .testTag("$NAVIGATION_RAIL_TEST_TAG/${item.name}"),
                                         selected = selectedItem == item.ordinal,
                                         onClick = {
                                             projectEditorNavigator.navigate(
@@ -185,27 +184,19 @@ fun ProjectEditorContent(
                                             )
                                             selectedItem = index
                                         },
-                                        modifier =
-                                            Modifier
-                                                .size(40.dp)
-                                                .padding(5.dp)
-                                                .testTag("$NAVIGATION_RAIL_TEST_TAG/${item.name}"),
-                                    ) { state ->
-                                        val tint by LocalIconButtonStyle.current.colors.foregroundFor(
-                                            state,
-                                        )
-                                        val painterProvider =
-                                            rememberResourcePainterProvider(
-                                                item.iconPath,
-                                                Icons::class.java,
-                                            )
-                                        val painter by painterProvider.getPainter(
-                                            org.jetbrains.jewel.ui.painter.hints
-                                                .Size(20),
-                                            Stroke(tint),
-                                        )
-                                        Icon(painter = painter, "icon")
-                                    }
+                                        icon = {
+                                            Box(
+                                                modifier = Modifier.fillMaxSize(),
+                                                contentAlignment = Alignment.Center,
+                                            ) {
+                                                Icon(
+                                                    modifier = Modifier.size(20.dp),
+                                                    imageVector = item.icon,
+                                                    contentDescription = "icon",
+                                                )
+                                            }
+                                        },
+                                    )
                                 }
                             }
                         }

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/navigationrail/LeftNavigationRail.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/navigationrail/LeftNavigationRail.kt
@@ -100,15 +100,7 @@ fun LeftNavigationRail(navigator: Navigator) {
                             modifier = Modifier.fillMaxSize(),
                             contentAlignment = Alignment.Center,
                         ) {
-                            val icon =
-                                when {
-                                    isSelected ->
-                                        item.icon.tint(
-                                            Color.White.copy(alpha = 1.0f),
-                                        )
-
-                                    else -> item.icon
-                                }
+                            val icon = if (isSelected) item.icon.tint(Color.White) else item.icon
                             Icon(
                                 modifier = Modifier.size(20.dp),
                                 imageVector = icon,
@@ -122,10 +114,7 @@ fun LeftNavigationRail(navigator: Navigator) {
     }
 }
 
-private fun ImageVector.tint(
-    strokeTint: Color,
-    fillTint: Color = Color.Transparent,
-): ImageVector {
+private fun ImageVector.tint(color: Color): ImageVector {
     val backgroundPalette =
         listOf(
             Color(0xFFFF43454A),
@@ -172,7 +161,7 @@ private fun ImageVector.tint(
                 val strokeValue = (node.stroke as? SolidColor)?.value
 
                 val palette =
-                    backgroundPalette.associateWith { fillTint } + strokeColors.associateWith { strokeTint }
+                    backgroundPalette.associateWith { Color.Transparent } + strokeColors.associateWith { color }
 
                 val newFill =
                     if (fillValue != null) {

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/navigationrail/LeftNavigationRail.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/navigationrail/LeftNavigationRail.kt
@@ -1,0 +1,246 @@
+package io.composeflow.ui.navigationrail
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItem
+import androidx.compose.material3.NavigationRailItemDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.VectorGroup
+import androidx.compose.ui.graphics.vector.VectorNode
+import androidx.compose.ui.graphics.vector.VectorPath
+import androidx.compose.ui.graphics.vector.group
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import io.composeflow.BuildConfig
+import io.composeflow.NAVIGATION_RAIL_TEST_TAG
+import io.composeflow.model.TopLevelDestination
+import io.composeflow.ui.Tooltip
+import moe.tlaster.precompose.navigation.NavOptions
+import moe.tlaster.precompose.navigation.Navigator
+import moe.tlaster.precompose.navigation.PopUpTo
+import org.jetbrains.jewel.ui.component.Icon
+import kotlin.math.absoluteValue
+
+@Composable
+fun LeftNavigationRail(navigator: Navigator) {
+    val currentDestination =
+        TopLevelDestination.entries.firstOrNull {
+            it.route ==
+                navigator.currentEntry
+                    .collectAsState(null)
+                    .value
+                    ?.route
+                    ?.route
+        }
+
+    var selectedItem by remember(currentDestination) {
+        mutableStateOf(
+            currentDestination?.ordinal ?: 0,
+        )
+    }
+    NavigationRail(
+        modifier =
+            Modifier
+                .width(40.dp)
+                .fillMaxHeight(),
+    ) {
+        TopLevelDestination.entries.forEachIndexed { index, item ->
+            @Suppress("KotlinConstantConditions")
+            if (BuildConfig.isRelease) {
+                if (item == TopLevelDestination.StringEditor) {
+                    return@forEachIndexed
+                }
+            }
+            val isSelected = selectedItem == item.ordinal
+            Tooltip(item.label) {
+                NavigationRailItem(
+                    modifier =
+                        Modifier
+                            .size(40.dp)
+                            .padding(5.dp)
+                            .clip(MaterialTheme.shapes.extraSmall)
+                            .testTag("$NAVIGATION_RAIL_TEST_TAG/${item.name}"),
+                    selected = isSelected,
+                    onClick = {
+                        navigator.navigate(
+                            item.route,
+                            options =
+                                NavOptions(
+                                    popUpTo =
+                                        PopUpTo(
+                                            route = item.route,
+                                        ),
+                                ),
+                        )
+                        selectedItem = index
+                    },
+                    colors =
+                        NavigationRailItemDefaults.colors(
+                            indicatorColor = Color(0xFF366ACE),
+                        ),
+                    icon = {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            val icon =
+                                when {
+                                    isSelected ->
+                                        item.icon.tint(
+                                            Color.White.copy(alpha = 1.0f),
+                                        )
+
+                                    else -> item.icon
+                                }
+                            Icon(
+                                modifier = Modifier.size(20.dp),
+                                imageVector = icon,
+                                contentDescription = "icon",
+                            )
+                        }
+                    },
+                )
+            }
+        }
+    }
+}
+
+private fun ImageVector.tint(
+    strokeTint: Color,
+    fillTint: Color = Color.Transparent,
+): ImageVector {
+    val backgroundPalette =
+        listOf(
+            Color(0xFFFF43454A),
+            Color(0xFFEBECF0),
+            Color(0xFFE7EFFD),
+            Color(0xFFDFF2E0),
+            Color(0xFFF2FCF3),
+            Color(0xFFFFE8E8),
+            Color(0xFFFFF5F5),
+            Color(0xFFFFF8E3),
+            Color(0xFFFFF4EB),
+            Color(0xFFEEE0FF),
+        )
+
+    val strokeColors =
+        listOf(
+            Color(0xFF000000),
+            Color(0xFF818594),
+            Color(0xFF6C707E),
+            Color(0xFF3574F0),
+            Color(0xFF5FB865),
+            Color(0xFFE35252),
+            Color(0xFFEB7171),
+            Color(0xFFE3AE4D),
+            Color(0xFFFCC75B),
+            Color(0xFFF28C35),
+            Color(0xFF548AF7),
+            Color(0xFFCED0D6),
+        )
+
+    fun Color.approxEquals(
+        other: Color,
+        epsilon: Float = 0.004f,
+    ): Boolean =
+        (red - other.red).absoluteValue < epsilon &&
+            (green - other.green).absoluteValue < epsilon &&
+            (blue - other.blue).absoluteValue < epsilon &&
+            (alpha - other.alpha).absoluteValue < epsilon
+
+    fun ImageVector.Builder.copyNode(node: VectorNode) {
+        when (node) {
+            is VectorPath -> {
+                val fillValue = (node.fill as? SolidColor)?.value
+                val strokeValue = (node.stroke as? SolidColor)?.value
+
+                val palette =
+                    backgroundPalette.associateWith { fillTint } + strokeColors.associateWith { strokeTint }
+
+                val newFill =
+                    if (fillValue != null) {
+                        val key = palette.keys.firstOrNull { it.approxEquals(fillValue) }
+                        val color = palette[key] ?: fillValue
+                        SolidColor(color)
+                    } else {
+                        node.fill
+                    }
+
+                val newStroke =
+                    if (strokeValue != null) {
+                        val key =
+                            palette.keys.firstOrNull {
+                                it.approxEquals(strokeValue)
+                            }
+                        val color = palette[key] ?: Color.Green
+
+                        SolidColor(color)
+                    } else {
+                        node.stroke
+                    }
+
+                addPath(
+                    pathData = node.pathData,
+                    pathFillType = node.pathFillType,
+                    name = node.name,
+                    fill = newFill,
+                    fillAlpha = node.fillAlpha,
+                    stroke = newStroke,
+                    strokeAlpha = node.strokeAlpha,
+                    strokeLineWidth = node.strokeLineWidth,
+                    strokeLineCap = node.strokeLineCap,
+                    strokeLineJoin = node.strokeLineJoin,
+                    strokeLineMiter = node.strokeLineMiter,
+                    trimPathStart = node.trimPathStart,
+                    trimPathEnd = node.trimPathEnd,
+                    trimPathOffset = node.trimPathOffset,
+                )
+            }
+
+            is VectorGroup -> {
+                group(
+                    name = node.name,
+                    rotate = node.rotation,
+                    pivotX = node.pivotX,
+                    pivotY = node.pivotY,
+                    scaleX = node.scaleX,
+                    scaleY = node.scaleY,
+                    translationX = node.translationX,
+                    translationY = node.translationY,
+                    clipPathData = node.clipPathData,
+                ) {
+                    node.forEach { child -> copyNode(child) }
+                }
+            }
+        }
+    }
+
+    return ImageVector
+        .Builder(
+            defaultWidth = this.defaultWidth,
+            defaultHeight = this.defaultHeight,
+            viewportWidth = this.viewportWidth,
+            viewportHeight = this.viewportHeight,
+        ).apply {
+            this@tint.root.forEach { node ->
+                copyNode(node)
+            }
+        }.build()
+}


### PR DESCRIPTION
This PR replaces the JVM-dependent custom NavigationRail implementation in ProjectEditorView with the native Jetpack Compose NavigationRail and NavigationRailItem, making it compatible with WASM.

Changes included:

- Removed custom JVM-dependent implementation (Column + Jewel SelectableIconButton).
- Introduced native NavigationRail and NavigationRailItem in LeftNavigationRail.
- Icons now use TopLevelDestination.icon (ImageVector) instead of iconPath (SVG).
- Simplified icon tinting logic in LeftNavigationRail to ensure consistent colors.

https://github.com/user-attachments/assets/3e2b6559-bc99-4bf0-8dd3-642feff328ef
