### PR TITLE
Fix extractContent of LlmClient to parse multiline content correctly

### DIFF
--- a/core/ai/src/commonMain/kotlin/io/composeflow/ai/LlmClient.kt
+++ b/core/ai/src/commonMain/kotlin/io/composeflow/ai/LlmClient.kt
@@ -319,7 +319,7 @@ class LlmClient(
         fun extractContent(input: String): String {
             // Use [\s\S] instead of . to match any character including line terminators.
 
-            // 1. Try to match ```json...``` first (with closing ```)
+            // 1. Try to match ```json...``` (with closing ```)
             val tripleJsonRegex = """```json[\s\n]*([\s\S]*?)[\s\n]*```""".toRegex()
             val tripleJsonMatch = tripleJsonRegex.find(input)
             if (tripleJsonMatch != null) {

--- a/core/ai/src/jvmTest/kotlin/io/composeflow/ai/LlmClientTest.kt
+++ b/core/ai/src/jvmTest/kotlin/io/composeflow/ai/LlmClientTest.kt
@@ -1,0 +1,208 @@
+package io.composeflow.ai
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LlmClientTest {
+    @Test
+    fun testExtractContent_jsonCodeBlock() {
+        val input =
+            """
+            Some text before
+            ```json
+            {
+                "key": "value",
+                "number": 42
+            }
+            ```
+            Some text after
+            """.trimIndent()
+
+        val expected =
+            """
+            {
+                "key": "value",
+                "number": 42
+            }
+            """.trimIndent()
+
+        assertEquals(expected, LlmClient.extractContent(input))
+    }
+
+    @Test
+    fun testExtractContent_jsonCodeBlockWithoutSurroundingTexts() {
+        val input =
+            """
+            ```json
+            {
+                "key": "value",
+                "number": 42
+            }
+            ```
+            """.trimIndent()
+
+        val expected =
+            """
+            {
+                "key": "value",
+                "number": 42
+            }
+            """.trimIndent()
+
+        assertEquals(expected, LlmClient.extractContent(input))
+    }
+
+    @Test
+    fun testExtractContent_jsonCodeBlockWithoutClosing() {
+        val input =
+            """
+            Some text before
+            ```json
+            {
+                "incomplete": "json",
+                "still": "works"
+            }
+            """.trimIndent()
+
+        val expected =
+            """
+            {
+                "incomplete": "json",
+                "still": "works"
+            }
+            """.trimIndent()
+
+        assertEquals(expected, LlmClient.extractContent(input))
+    }
+
+    @Test
+    fun testExtractContent_genericCodeBlock() {
+        val input =
+            """
+            Some text before
+            ```
+            {
+                "name": "test",
+                "enabled": true
+            }
+            ```
+            Some text after
+            """.trimIndent()
+
+        val expected =
+            """
+            {
+                "name": "test",
+                "enabled": true
+            }
+            """.trimIndent()
+
+        assertEquals(expected, LlmClient.extractContent(input))
+    }
+
+    @Test
+    fun testExtractContent_noCodeBlock() {
+        val input =
+            """
+            {
+                "name": "test",
+                "enabled": true
+            }
+            """.trimIndent()
+
+        val expected =
+            """
+            {
+                "name": "test",
+                "enabled": true
+            }
+            """.trimIndent()
+
+        assertEquals(expected, LlmClient.extractContent(input))
+    }
+
+    @Test
+    fun testExtractContent_jsonCodeBlockWithWhitespace() {
+        val input =
+            """
+            ```json
+            {"data": "value"}
+              ```
+            """.trimIndent()
+
+        val expected = """{"data": "value"}"""
+
+        assertEquals(expected, LlmClient.extractContent(input))
+    }
+
+    @Test
+    fun testExtractContent_emptyJsonCodeBlock() {
+        val input =
+            """
+            ```json
+            ```
+            """.trimIndent()
+
+        val expected = ""
+
+        assertEquals(expected, LlmClient.extractContent(input))
+    }
+
+    @Test
+    fun testExtractContent_multipleCodeBlocks_selectsFirst() {
+        val input =
+            """
+            ```json
+            {"first": "block"}
+            ```
+
+            ```json
+            {"second": "block"}
+            ```
+            """.trimIndent()
+
+        val expected = """{"first": "block"}"""
+
+        assertEquals(expected, LlmClient.extractContent(input))
+    }
+
+    @Test
+    fun testExtractContent_tripleBackticksWithNestedBackticks() {
+        // Triple backticks code block should properly handle nested backticks
+        val input =
+            """
+            ```json
+            {
+                "content": "some `backticks` inside"
+            }
+            ```
+            """.trimIndent()
+
+        val expected =
+            """
+            {
+                "content": "some `backticks` inside"
+            }
+            """.trimIndent()
+
+        assertEquals(expected, LlmClient.extractContent(input))
+    }
+
+    @Test
+    fun testExtractContent_singleLineJsonCodeBlock() {
+        val input = """```json {"inline": "json"}```"""
+
+        val expected = """{"inline": "json"}"""
+
+        assertEquals(expected, LlmClient.extractContent(input))
+    }
+
+    @Test
+    fun testExtractContent_singleLineSingleBlacktick() {
+        val input = """`json {"inline": "json"}`"""
+
+        val expected = """{"inline": "json"}"""
+
+        assertEquals(expected, LlmClient.extractContent(input))
+    }
+}


### PR DESCRIPTION
Close #113.

### Cause

Regex dot `.` doesn't match line terminators by default ([reference](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#lt)) and the regex used in `extractContent` can't capture the entire JSON content if it contains newlines.

We used `RegexOption.DOT_MATCHES_ALL` to make a dot to match any characters, but we stopped using the option because it's JVM specific.

### Solution

Use `[\s\S]` instead of `.` in the regex to capture JSON contents.

### Additional fixes

Support parsing JSON which is surrounded by json code block and contains single blacktick in the content.