### PR TITLE
Fix list_screens tool to deserialize arguments and serialize screen list successfully

### DIFF
--- a/core/ai/src/commonMain/kotlin/io/composeflow/ai/openrouter/tools/OpenRouterToolResultSerializer.kt
+++ b/core/ai/src/commonMain/kotlin/io/composeflow/ai/openrouter/tools/OpenRouterToolResultSerializer.kt
@@ -317,7 +317,7 @@ object OpenRouterToolResultSerializer : KSerializer<OpenRouterToolResult> {
         val processedToolArgsElement =
             if (toolArgsElement is JsonPrimitive && toolArgsElement.isString) {
                 try {
-                    json.parseToJsonElement(toolArgsElement.content)
+                    json.parseToJsonElement(toolArgsElement.content.ifEmpty { "{}" })
                 } catch (e: Exception) {
                     throw SerializationException("Failed to parse tool_args JSON string: ${e.message}")
                 }

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ai/ToolDispatcher.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ai/ToolDispatcher.kt
@@ -9,6 +9,7 @@ import io.composeflow.ui.EventResult
 import io.composeflow.ui.appstate.AppStateEditorOperator
 import io.composeflow.ui.datatype.DataTypeEditorOperator
 import io.composeflow.ui.uibuilder.UiBuilderOperator
+import io.composeflow.ui.uibuilder.toScreenSummary
 
 /**
  * Handles dispatching tool execution requests to appropriate operators.
@@ -318,18 +319,7 @@ class ToolDispatcher(
                     val result = uiBuilderOperator.onListScreens(project)
                     if (result.errorMessages.isEmpty()) {
                         val screens = project.screenHolder.screens
-                        val screenList =
-                            screens.map { screen ->
-                                mapOf(
-                                    "id" to screen.id,
-                                    "name" to screen.name,
-                                    "title" to screen.title.value,
-                                    "label" to screen.label.value,
-                                    "isDefault" to screen.isDefault.value,
-                                    "isSelected" to screen.isSelected.value,
-                                    "showOnNavigation" to screen.showOnNavigation.value,
-                                )
-                            }
+                        val screenList = screens.map { it.toScreenSummary() }
                         toolArgs.result = encodeToString(screenList)
                     } else {
                         toolArgs.result = result.errorMessages.joinToString("; ")

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/uibuilder/UiBuilderOperator.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/uibuilder/UiBuilderOperator.kt
@@ -19,6 +19,7 @@ import io.composeflow.serializer.decodeFromStringWithFallback
 import io.composeflow.ui.EventResult
 import io.composeflow.ui.UiBuilderHelper
 import io.composeflow.ui.UiBuilderHelper.addNodeToCanvasEditable
+import kotlinx.serialization.Serializable
 import org.jetbrains.compose.resources.getString
 
 /**
@@ -513,18 +514,7 @@ class UiBuilderOperator {
         val result = EventResult()
         try {
             val screens = project.screenHolder.screens
-            val screenList =
-                screens.map { screen ->
-                    mapOf(
-                        "id" to screen.id,
-                        "name" to screen.name,
-                        "title" to screen.title.value,
-                        "label" to screen.label.value,
-                        "isDefault" to screen.isDefault.value,
-                        "isSelected" to screen.isSelected.value,
-                        "showOnNavigation" to screen.showOnNavigation.value,
-                    )
-                }
+            val screenList = screens.map { it.toScreenSummary() }
 
             Logger.i { "Listed ${screens.size} screens in project" }
             screens.forEach { screen ->
@@ -567,3 +557,28 @@ class UiBuilderOperator {
         return result
     }
 }
+
+/**
+ * Data class representing a screen summary for AI tools.
+ */
+@Serializable
+data class ScreenSummary(
+    val id: String,
+    val name: String,
+    val title: String,
+    val label: String,
+    val isDefault: Boolean,
+    val isSelected: Boolean,
+    val showOnNavigation: Boolean,
+)
+
+fun Screen.toScreenSummary() =
+    ScreenSummary(
+        id = id,
+        name = name,
+        title = title.value,
+        label = label.value,
+        isDefault = isDefault.value,
+        isSelected = isSelected.value,
+        showOnNavigation = showOnNavigation.value,
+    )


### PR DESCRIPTION
Close #115, Close #116.

For #115, added `ScreenSummary` serializable class with `@Serializable` annotation to serialize screen list for list_screen tool call. It looks like serializing `Map` which uses mixed types as the value is not easy. b610b895edc7ed57588d88706baa928433f53525

For #116, it seems `parseToJsonElement` fails with an empty string, so use `{}` instead if the received `tool_args` is empty. 9793ffd370bbb896ae9b1880d5d5581000fba746