### PR TITLE
Check exception type to detect missing YAML type tag

### DIFF
--- a/core/model/src/commonMain/kotlin/io/composeflow/serializer/YamlSerializer.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/serializer/YamlSerializer.kt
@@ -58,7 +58,16 @@ val yamlPropertyBasedSerializer =
  * Checks if this throwable or any of its causes is a [MissingTypeTagException].
  */
 val Throwable.isCausedByMissingTypeTag: Boolean
-    get() = this is MissingTypeTagException || this.cause?.isCausedByMissingTypeTag == true
+    get() {
+        var current: Throwable? = this
+        while (current != null) {
+            if (current is MissingTypeTagException) {
+                return true
+            }
+            current = current.cause
+        }
+        return false
+    }
 
 /**
  * Wrapper method that attempts to decode using yamlDefaultSerializer first,


### PR DESCRIPTION
Close #119.

Changes to check if an exception is `MissingTypeTagException` instead of checking exception message to detect missing YAML type tag and fallback to property based serialization.