### PR TITLE
Replace Jewel Top Toolbar with a WASM-compatible implementation

### DIFF
--- a/core/model/src/commonMain/kotlin/io/composeflow/custom/composeflowicons/ComposeFlowLogo.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/custom/composeflowicons/ComposeFlowLogo.kt
@@ -1,0 +1,98 @@
+package io.composeflow.custom.composeflowicons
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import io.composeflow.custom.ComposeFlowIcons
+
+val ComposeFlowIcons.ComposeFlowLogo: ImageVector
+    get() {
+        if (_ComposeFlowLogo != null) {
+            return _ComposeFlowLogo!!
+        }
+        _ComposeFlowLogo =
+            ImageVector
+                .Builder(
+                    name = "IconName",
+                    defaultWidth = 1000.dp,
+                    defaultHeight = 1000.dp,
+                    viewportWidth = 1000f,
+                    viewportHeight = 1000f,
+                ).apply {
+                    path(
+                        fill = SolidColor(Color(0xFFFEFEFE)),
+                        fillAlpha = 0.999f,
+                        strokeAlpha = 0.999f,
+                    ) {
+                        moveTo(244.5f, 139.5f)
+                        curveTo(414.2f, 139.3f, 583.8f, 139.5f, 753.5f, 140f)
+                        curveTo(804.4f, 148.3f, 838.3f, 176.8f, 855f, 225.5f)
+                        curveTo(856.8f, 232.1f, 858.2f, 238.7f, 859f, 245.5f)
+                        curveTo(859.7f, 414.8f, 859.7f, 584.2f, 859f, 753.5f)
+                        curveTo(850.7f, 804.4f, 822.2f, 838.3f, 773.5f, 855f)
+                        curveTo(766.9f, 856.8f, 760.3f, 858.2f, 753.5f, 859f)
+                        curveTo(583.8f, 859.7f, 414.2f, 859.7f, 244.5f, 859f)
+                        curveTo(194.1f, 850.3f, 160.6f, 821.8f, 144f, 773.5f)
+                        curveTo(142.2f, 766.9f, 140.8f, 760.3f, 140f, 753.5f)
+                        curveTo(139.3f, 583.8f, 139.3f, 414.2f, 140f, 244.5f)
+                        curveTo(151f, 185.6f, 185.9f, 150.6f, 244.5f, 139.5f)
+                        close()
+                    }
+                    path(fill = SolidColor(Color(0xFF72CA91))) {
+                        moveTo(381.5f, 494.5f)
+                        curveTo(377f, 473.2f, 363.8f, 461.5f, 342f, 459.5f)
+                        curveTo(322.2f, 461.1f, 309.1f, 471.1f, 302.5f, 489.5f)
+                        curveTo(307.7f, 416.7f, 341f, 360.5f, 402.5f, 321f)
+                        curveTo(437.8f, 300.6f, 475.6f, 290.7f, 516f, 291.5f)
+                        curveTo(540.7f, 298.6f, 551.7f, 314.9f, 549f, 340.5f)
+                        curveTo(543.3f, 360.5f, 530.3f, 370.8f, 510f, 371.5f)
+                        curveTo(450.1f, 375.5f, 409.4f, 405.5f, 388f, 461.5f)
+                        curveTo(385.2f, 472.5f, 383f, 483.5f, 381.5f, 494.5f)
+                        close()
+                    }
+                    path(fill = SolidColor(Color(0xFF63C485))) {
+                        moveTo(617.5f, 337.5f)
+                        curveTo(634.7f, 335.3f, 648.5f, 341f, 659f, 354.5f)
+                        curveTo(670.4f, 374.1f, 667.5f, 392f, 650.5f, 408f)
+                        curveTo(629.9f, 421.1f, 611.1f, 418.9f, 594f, 401.5f)
+                        curveTo(580f, 378.9f, 583.5f, 359.4f, 604.5f, 343f)
+                        curveTo(608.8f, 340.7f, 613.1f, 338.9f, 617.5f, 337.5f)
+                        close()
+                    }
+                    path(fill = SolidColor(Color(0xFF4C80F0))) {
+                        moveTo(381.5f, 494.5f)
+                        curveTo(381.5f, 495.2f, 381.5f, 495.8f, 381.5f, 496.5f)
+                        curveTo(381.1f, 499.8f, 381.1f, 503f, 381.5f, 506f)
+                        curveTo(375.4f, 528.9f, 359.7f, 539.6f, 334.5f, 538f)
+                        curveTo(318.5f, 533.9f, 307.9f, 524f, 302.5f, 508.5f)
+                        curveTo(301.3f, 502.5f, 301.3f, 496.2f, 302.5f, 489.5f)
+                        curveTo(309.1f, 471.1f, 322.2f, 461.1f, 342f, 459.5f)
+                        curveTo(363.8f, 461.5f, 377f, 473.2f, 381.5f, 494.5f)
+                        close()
+                    }
+                    path(fill = SolidColor(Color(0xFF5D8CF0))) {
+                        moveTo(381.5f, 496.5f)
+                        curveTo(384.3f, 557.7f, 414.3f, 599.2f, 471.5f, 621f)
+                        curveTo(522.2f, 634.8f, 566.4f, 622.9f, 604f, 585.5f)
+                        curveTo(612.3f, 575.5f, 619.7f, 564.9f, 626f, 553.5f)
+                        curveTo(642f, 537.9f, 659.8f, 535.4f, 679.5f, 546f)
+                        curveTo(693.8f, 557.1f, 699.3f, 571.6f, 696f, 589.5f)
+                        curveTo(682.9f, 618.6f, 663.7f, 643.1f, 638.5f, 663f)
+                        curveTo(583.9f, 703.5f, 523.5f, 716.1f, 457.5f, 701f)
+                        curveTo(368.9f, 673.7f, 317.4f, 614.2f, 303f, 522.5f)
+                        curveTo(302.8f, 518.2f, 302.3f, 514.1f, 301.5f, 510f)
+                        curveTo(302.1f, 509.6f, 302.4f, 509.1f, 302.5f, 508.5f)
+                        curveTo(307.9f, 524f, 318.5f, 533.9f, 334.5f, 538f)
+                        curveTo(359.7f, 539.6f, 375.4f, 528.9f, 381.5f, 506f)
+                        curveTo(381.1f, 503f, 381.1f, 499.8f, 381.5f, 496.5f)
+                        close()
+                    }
+                }.build()
+
+        return _ComposeFlowLogo!!
+    }
+
+@Suppress("ObjectPropertyName")
+private var _ComposeFlowLogo: ImageVector? = null

--- a/core/ui/src/commonMain/kotlin/io/composeflow/ui/window/ComposeFlowWindow.kt
+++ b/core/ui/src/commonMain/kotlin/io/composeflow/ui/window/ComposeFlowWindow.kt
@@ -1,0 +1,27 @@
+package io.composeflow.ui.window
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.input.key.KeyEvent
+import io.composeflow.ui.window.styling.TitleBarStyle
+import io.composeflow.ui.window.styling.dark
+
+@Composable
+expect fun ComposeFlowWindow(
+    windowController: WindowController =
+        remember {
+            WindowController()
+        },
+    titleBarStyle: TitleBarStyle = TitleBarStyle.dark(),
+    resizable: Boolean = true,
+    onWindowIconClicked: (() -> Unit)? = null,
+    onCloseRequest: () -> Unit = {},
+    onRequestMinimize: (() -> Unit)? = {
+    },
+    onRequestToggleMaximize: (() -> Unit)? = {
+    },
+    onKeyEvent: (KeyEvent) -> Boolean = { false },
+    alwaysOnTop: Boolean = false,
+    preventMinimize: Boolean = onRequestMinimize == null,
+    content: @Composable () -> Unit,
+)

--- a/core/ui/src/commonMain/kotlin/io/composeflow/ui/window/TileBarShared.kt
+++ b/core/ui/src/commonMain/kotlin/io/composeflow/ui/window/TileBarShared.kt
@@ -1,0 +1,165 @@
+package io.composeflow.ui.window
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import io.composeflow.ui.window.styling.TitleBarStyle
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+internal fun CommonTitleBarContent(
+    modifier: Modifier,
+    title: String,
+    windowIcon: Painter?,
+    showTitle: Boolean,
+    showWindowIcon: Boolean,
+    start: @Composable (() -> Unit)?,
+    end: @Composable (() -> Unit)?,
+    onWindowIconClicked: (() -> Unit)?,
+) {
+    Box(
+        modifier = modifier,
+    ) {
+        Row(
+            Modifier.fillMaxHeight(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Spacer(Modifier.width(16.dp))
+
+            if (showWindowIcon) {
+                windowIcon?.let {
+                    Image(
+                        painter = it,
+                        contentDescription = null,
+                        modifier =
+                            Modifier.size(36.dp).clip(RoundedCornerShape(4.dp)).then(
+                                if (onWindowIconClicked != null) {
+                                    Modifier.clickable { onWindowIconClicked() }
+                                } else {
+                                    Modifier
+                                },
+                            ),
+                    )
+                }
+            }
+
+            start?.let {
+                start()
+            }
+        }
+
+        if (showTitle) {
+            Text(
+                modifier = Modifier.align(Alignment.Center),
+                text = title,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+
+        end?.let {
+            Row(
+                modifier = Modifier.align(Alignment.CenterEnd),
+            ) {
+                end()
+                Spacer(Modifier.width(8.dp))
+            }
+        }
+    }
+}
+
+@Composable
+internal fun CommonRenderTitleBar(
+    modifier: Modifier,
+    titleBar: TitleBar,
+    title: String,
+    windowIcon: Painter? = null,
+    style: TitleBarStyle,
+    showTitle: Boolean,
+    showWindowIcon: Boolean,
+    start: (@Composable () -> Unit)?,
+    end: (@Composable () -> Unit)?,
+    onWindowIconClicked: (() -> Unit)?,
+    onRequestClose: () -> Unit,
+    onRequestMinimize: (() -> Unit)?,
+    onRequestToggleMaximize: (() -> Unit)?,
+) {
+    val systemButtonsAtFirst = titleBar.systemButtonsPosition.isLeft
+    val density = LocalDensity.current
+    val background = style.colors.background
+    val gradientStartColor = style.colors.gradientStartColor
+
+    val backgroundBrush =
+        remember {
+            with(density) {
+                Brush.horizontalGradient(
+                    0.0f to background,
+                    0.5f to gradientStartColor,
+                    1.0f to background,
+                    startX = style.metrics.gradientStartX.toPx(),
+                    endX = style.metrics.gradientEndX.toPx(),
+                )
+            }
+        }
+
+    Row(
+        modifier = modifier.background(backgroundBrush).height(titleBar.titleBarHeight),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (systemButtonsAtFirst) {
+            titleBar.RenderSystemButtons(
+                onRequestClose = onRequestClose,
+                onRequestMinimize = onRequestMinimize,
+                onToggleMaximize = onRequestToggleMaximize,
+            )
+        }
+
+        titleBar.RenderTitleBarContent(
+            title = title,
+            modifier = Modifier.weight(1f),
+            windowIcon = windowIcon,
+            showTitle = showTitle,
+            showWindowIcon = showWindowIcon,
+            start = start,
+            end = end,
+            onWindowIconClicked = onWindowIconClicked,
+        )
+
+        if (!systemButtonsAtFirst) {
+            titleBar.RenderSystemButtons(
+                onRequestClose = onRequestClose,
+                onRequestMinimize = onRequestMinimize,
+                onToggleMaximize = onRequestToggleMaximize,
+            )
+        }
+    }
+}
+
+fun Modifier.windowButton(): Modifier =
+    fillMaxHeight()
+        .wrapContentHeight()
+        .padding(
+            horizontal = 15.dp,
+        ).requiredSize(15.dp)

--- a/core/ui/src/commonMain/kotlin/io/composeflow/ui/window/TitleBar.kt
+++ b/core/ui/src/commonMain/kotlin/io/composeflow/ui/window/TitleBar.kt
@@ -1,0 +1,67 @@
+package io.composeflow.ui.window
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.composeflow.ui.window.styling.TitleBarStyle
+
+interface TitleBar {
+    val titleBarHeight: Dp
+        get() = DefaultTitleBarHeigh
+    val systemButtonsPosition: SystemButtonsPosition
+
+    @Composable
+    fun RenderSystemButtons(
+        onRequestClose: () -> Unit,
+        onRequestMinimize: (() -> Unit)?,
+        onToggleMaximize: (() -> Unit)?,
+    )
+
+    @Composable
+    fun RenderTitleBarContent(
+        title: String,
+        modifier: Modifier,
+        windowIcon: Painter?,
+        showTitle: Boolean,
+        showWindowIcon: Boolean,
+        start: (@Composable () -> Unit)?,
+        end: (@Composable () -> Unit)?,
+        onWindowIconClicked: (() -> Unit)?,
+    )
+
+    @Composable
+    fun RenderTitleBar(
+        modifier: Modifier,
+        titleBar: TitleBar,
+        title: String,
+        windowIcon: Painter?,
+        showTitle: Boolean,
+        showWindowIcon: Boolean,
+        style: TitleBarStyle,
+        start: (@Composable () -> Unit)?,
+        end: (@Composable () -> Unit)?,
+        onWindowIconClicked: (() -> Unit)?,
+        onRequestClose: () -> Unit,
+        onRequestMinimize: (() -> Unit)?,
+        onRequestToggleMaximize: (() -> Unit)?,
+    )
+
+    companion object {
+        val DefaultTitleBarHeigh = 40.dp
+    }
+}
+
+expect fun TitleBar.Companion.getPlatformTitleBar(): TitleBar
+
+enum class SystemButtonType {
+    Close,
+    Minimize,
+    Maximize,
+}
+
+data class SystemButtonsPosition(
+    val buttons: List<SystemButtonType>,
+    val isLeft: Boolean,
+)

--- a/core/ui/src/commonMain/kotlin/io/composeflow/ui/window/WindowController.kt
+++ b/core/ui/src/commonMain/kotlin/io/composeflow/ui/window/WindowController.kt
@@ -1,0 +1,54 @@
+package io.composeflow.ui.window
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.painter.Painter
+
+class WindowController(
+    title: String? = null,
+    icon: Painter? = null,
+) {
+    var title by mutableStateOf(title)
+    var icon by mutableStateOf(icon)
+    var start: (@Composable () -> Unit)? by mutableStateOf(null)
+    var end: (@Composable () -> Unit)? by mutableStateOf(null)
+    var showTitleInTitleBar by mutableStateOf(false)
+    var showWindowIconInTitleBar by mutableStateOf(false)
+}
+
+@Composable
+fun rememberWindowController(
+    title: String? = null,
+    icon: Painter? = null,
+    showTitleInTitleBar: Boolean = false,
+    showWindowIconInTitleBar: Boolean = false,
+): WindowController {
+    val controller =
+        remember {
+            WindowController(
+                title,
+                icon,
+            )
+        }
+    LaunchedEffect(title) {
+        controller.title = title
+    }
+    LaunchedEffect(icon) {
+        controller.icon = icon
+    }
+    LaunchedEffect(showTitleInTitleBar) {
+        controller.showTitleInTitleBar = showTitleInTitleBar
+    }
+    LaunchedEffect(showWindowIconInTitleBar) {
+        controller.showWindowIconInTitleBar = showWindowIconInTitleBar
+    }
+    return controller
+}
+
+val LocalWindowController =
+    compositionLocalOf<WindowController> { error("window controller not provided") }

--- a/core/ui/src/commonMain/kotlin/io/composeflow/ui/window/styling/TitleBarStyle.kt
+++ b/core/ui/src/commonMain/kotlin/io/composeflow/ui/window/styling/TitleBarStyle.kt
@@ -1,0 +1,64 @@
+package io.composeflow.ui.window.styling
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Stable
+data class TitleBarStyle(
+    val colors: TitleBarColors,
+    val metrics: TitleBarMetrics,
+) {
+    companion object
+}
+
+@Immutable
+data class TitleBarColors(
+    val background: Color,
+    val gradientStartColor: Color,
+) {
+    companion object
+}
+
+@Immutable
+data class TitleBarMetrics(
+    val height: Dp,
+    val gradientStartX: Dp,
+    val gradientEndX: Dp,
+) {
+    companion object
+}
+
+@Composable
+fun TitleBarStyle.Companion.dark(
+    colors: TitleBarColors = TitleBarColors.dark(),
+    metrics: TitleBarMetrics = TitleBarMetrics.default(),
+): TitleBarStyle =
+    TitleBarStyle(
+        colors = colors,
+        metrics = metrics,
+    )
+
+@Composable
+fun TitleBarColors.Companion.dark(
+    backgroundColor: Color = Color(0xFF2B2D30),
+    gradientStartColor: Color = Color(0xFFB0C6FF),
+): TitleBarColors =
+    TitleBarColors(
+        background = backgroundColor,
+        gradientStartColor = gradientStartColor,
+    )
+
+fun TitleBarMetrics.Companion.default(
+    height: Dp = 40.dp,
+    gradientStartX: Dp = (-100).dp,
+    gradientEndX: Dp = 400.dp,
+): TitleBarMetrics =
+    TitleBarMetrics(
+        height = height,
+        gradientStartX = gradientStartX,
+        gradientEndX = gradientEndX,
+    )

--- a/core/ui/src/jvmMain/kotlin/io/composeflow/ui/jewel/TitleBarContent.kt
+++ b/core/ui/src/jvmMain/kotlin/io/composeflow/ui/jewel/TitleBarContent.kt
@@ -1,6 +1,5 @@
 package io.composeflow.ui.jewel
 
 import androidx.compose.runtime.Composable
-import org.jetbrains.jewel.window.DecoratedWindowScope
 
-typealias TitleBarContent = @Composable DecoratedWindowScope.() -> Unit
+typealias TitleBarContent = @Composable () -> Unit

--- a/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/CustomWindow.jvm.kt
+++ b/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/CustomWindow.jvm.kt
@@ -1,0 +1,49 @@
+package io.composeflow.ui.window
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.window.WindowPlacement
+import androidx.compose.ui.window.rememberWindowState
+import io.composeflow.ui.window.frame.CustomWindow
+import io.composeflow.ui.window.styling.TitleBarStyle
+
+@Composable
+actual fun ComposeFlowWindow(
+    windowController: WindowController,
+    titleBarStyle: TitleBarStyle,
+    resizable: Boolean,
+    onWindowIconClicked: (() -> Unit)?,
+    onCloseRequest: () -> Unit,
+    onRequestMinimize: (() -> Unit)?,
+    onRequestToggleMaximize: (() -> Unit)?,
+    onKeyEvent: (KeyEvent) -> Boolean,
+    alwaysOnTop: Boolean,
+    preventMinimize: Boolean,
+    content: @Composable (() -> Unit),
+) {
+    val state = rememberWindowState(WindowPlacement.Maximized)
+    CustomWindow(
+        state = state,
+        onCloseRequest = onCloseRequest,
+        resizable = resizable,
+        titleBarStyle = titleBarStyle,
+        onWindowIconClicked = onWindowIconClicked,
+        onRequestMinimize = {
+            state.isMinimized = true
+        },
+        onRequestToggleMaximize = {
+            if (state.placement == WindowPlacement.Maximized) {
+                state.placement = WindowPlacement.Floating
+            } else {
+                state.placement = WindowPlacement.Maximized
+            }
+        },
+        onKeyEvent = onKeyEvent,
+        alwaysOnTop = alwaysOnTop,
+        preventMinimize = preventMinimize,
+        windowController = windowController,
+        content = {
+            content()
+        },
+    )
+}

--- a/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/SystemButtonsPositionProvider.kt
+++ b/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/SystemButtonsPositionProvider.kt
@@ -1,0 +1,5 @@
+package io.composeflow.ui.window
+
+interface SystemButtonsPositionProvider {
+    fun getPositions(): SystemButtonsPosition?
+}

--- a/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/TitleBar.jvm.kt
+++ b/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/TitleBar.jvm.kt
@@ -1,0 +1,15 @@
+package io.composeflow.ui.window
+
+import io.composeflow.CurrentOs
+import io.composeflow.currentOs
+import io.composeflow.ui.window.titlebar.linux.LinuxTitleBar
+import io.composeflow.ui.window.titlebar.mac.MacTitleBar
+import io.composeflow.ui.window.titlebar.windows.WindowsTitleBar
+
+actual fun TitleBar.Companion.getPlatformTitleBar(): TitleBar =
+    when (currentOs) {
+        CurrentOs.Windows -> WindowsTitleBar
+        CurrentOs.Linux -> LinuxTitleBar
+        CurrentOs.Mac -> MacTitleBar
+        CurrentOs.Other -> error("Unsupported platform $currentOs")
+    }

--- a/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/frame/CustomWindowFrame.kt
+++ b/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/frame/CustomWindowFrame.kt
@@ -1,0 +1,468 @@
+package io.composeflow.ui.window.frame
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.waitForUpOrCancellation
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.window.WindowDraggableArea
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.FrameWindowScope
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowPlacement
+import androidx.compose.ui.window.WindowState
+import com.jetbrains.JBR
+import com.jetbrains.WindowDecorations
+import com.jetbrains.WindowMove
+import io.composeflow.ui.window.LocalWindowController
+import io.composeflow.ui.window.TitleBar
+import io.composeflow.ui.window.WindowController
+import io.composeflow.ui.window.getPlatformTitleBar
+import io.composeflow.ui.window.styling.TitleBarStyle
+import io.composeflow.ui.window.titlebar.windows.applyUiScale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
+import java.awt.Window
+import java.awt.event.MouseEvent
+
+@Composable
+private fun FrameWindowScope.CustomWindowFrame(
+    onWindowIconClicked: (() -> Unit)?,
+    onRequestMinimize: (() -> Unit)?,
+    onRequestClose: () -> Unit,
+    onRequestToggleMaximize: (() -> Unit)?,
+    title: String,
+    titleBarStyle: TitleBarStyle,
+    showTitleInTitleBar: Boolean,
+    showWindowIconInTitleBar: Boolean,
+    windowIcon: Painter? = null,
+    background: Color,
+    start: (@Composable () -> Unit)?,
+    end: (@Composable () -> Unit)?,
+    content: @Composable () -> Unit,
+) {
+    Column(
+        Modifier
+            .fillMaxSize()
+            .ifThen(!JBR.isWindowDecorationsSupported()) {
+                ifThen(isWindowFloating()) {
+                    border(1.dp, Color.Gray.copy(0.25f), RectangleShape).padding(1.dp)
+                }
+            }.background(background),
+    ) {
+        SnapDraggableToolbar(
+            title = title,
+            windowIcon = windowIcon,
+            titleBarStyle = titleBarStyle,
+            showTitleInTitleBar = showTitleInTitleBar,
+            showWindowIconInTitleBar = showWindowIconInTitleBar,
+            start = start,
+            end = end,
+            onWindowIconClicked = onWindowIconClicked,
+            onRequestMinimize = onRequestMinimize,
+            onRequestClose = onRequestClose,
+            onRequestToggleMaximize = onRequestToggleMaximize,
+        )
+
+        content()
+    }
+}
+
+@Composable
+fun isWindowFocused(): Boolean = LocalWindowInfo.current.isWindowFocused
+
+@Composable
+fun isWindowMaximized(): Boolean = LocalWindowState.current.placement == WindowPlacement.Maximized
+
+@Composable
+fun isWindowFloating(): Boolean = LocalWindowState.current.placement == WindowPlacement.Floating
+
+@Composable
+fun FrameWindowScope.SnapDraggableToolbar(
+    title: String,
+    windowIcon: Painter? = null,
+    titleBarStyle: TitleBarStyle,
+    showTitleInTitleBar: Boolean,
+    showWindowIconInTitleBar: Boolean,
+    start: (@Composable () -> Unit)?,
+    end: (@Composable () -> Unit)?,
+    onWindowIconClicked: (() -> Unit)?,
+    onRequestMinimize: (() -> Unit)?,
+    onRequestToggleMaximize: (() -> Unit)?,
+    onRequestClose: () -> Unit,
+) {
+    val titleBar = TitleBar.getPlatformTitleBar()
+    if (JBR.isWindowDecorationsSupported()) {
+        val density = LocalDensity.current
+        val uiScale = LocalUiScale.current
+
+        fun computeHeaderHeight(height: Dp): Float = height.value.applyUiScale(uiScale)
+
+        var headerHeight by remember {
+            mutableStateOf(computeHeaderHeight(titleBar.titleBarHeight))
+        }
+        val customTitleBar =
+            remember {
+                JBR.getWindowDecorations().createCustomTitleBar()
+            }
+        LaunchedEffect(headerHeight) {
+            customTitleBar.height = headerHeight
+            customTitleBar.putProperty("controls.visible", false)
+            JBR.getWindowDecorations().setCustomTitleBar(window, customTitleBar)
+        }
+        Box(
+            Modifier.onSizeChanged {
+                headerHeight =
+                    computeHeaderHeight(
+                        density.run { it.height.toDp() },
+                    )
+            },
+        ) {
+            Spacer(
+                Modifier.matchParentSize().customTitleBarMouseEventHandler(customTitleBar),
+            )
+            FrameContent(
+                titleBar = titleBar,
+                modifier = Modifier,
+                title = title,
+                windowIcon = windowIcon,
+                showTitleInTitleBar = showTitleInTitleBar,
+                showWindowIconInTitleBar = showWindowIconInTitleBar,
+                titleBarStyle = titleBarStyle,
+                start = start,
+                end = end,
+                onRequestMinimize = onRequestMinimize,
+                onRequestToggleMaximize = onRequestToggleMaximize,
+                onRequestClose = onRequestClose,
+                onWindowIconClicked = onWindowIconClicked,
+            )
+        }
+    } else {
+        SystemDraggableSection(
+            onRequestToggleMaximize = onRequestToggleMaximize,
+        ) { modifier ->
+            FrameContent(
+                titleBar = titleBar,
+                modifier = modifier,
+                title = title,
+                windowIcon = windowIcon,
+                showTitleInTitleBar = showTitleInTitleBar,
+                showWindowIconInTitleBar = showWindowIconInTitleBar,
+                titleBarStyle = titleBarStyle,
+                start = start,
+                end = end,
+                onRequestMinimize = onRequestMinimize,
+                onRequestToggleMaximize = onRequestToggleMaximize,
+                onRequestClose = onRequestClose,
+                onWindowIconClicked = onWindowIconClicked,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+internal fun FrameWindowScope.SystemDraggableSection(
+    onRequestToggleMaximize: (() -> Unit)?,
+    content: @Composable (Modifier) -> Unit,
+) {
+    val windowMove: WindowMove? = JBR.getWindowMove()
+    val viewConfig = LocalViewConfiguration.current
+    var lastPress by remember { mutableStateOf(0L) }
+    if (windowMove != null) {
+        content(
+            Modifier.onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
+                if (this.currentEvent.button == PointerButton.Primary && this.currentEvent.changes.any { changed -> !changed.isConsumed }) {
+                    windowMove.startMovingTogetherWithMouse(window, MouseEvent.BUTTON1)
+                    if (System.currentTimeMillis() - lastPress in viewConfig.doubleTapMinTimeMillis..viewConfig.doubleTapTimeoutMillis) {
+                        onRequestToggleMaximize?.invoke()
+                    }
+                    lastPress = System.currentTimeMillis()
+                }
+            },
+        )
+    } else {
+        WindowDraggableArea {
+            content(Modifier)
+        }
+    }
+}
+
+internal fun Modifier.customTitleBarMouseEventHandler(titleBar: WindowDecorations.CustomTitleBar): Modifier =
+    pointerInput(Unit) {
+        val currentContext = currentCoroutineContext()
+        awaitPointerEventScope {
+            var inUserControl = false
+            while (currentContext.isActive) {
+                val event = awaitPointerEvent(PointerEventPass.Main)
+                event.changes.forEach {
+                    if (!it.isConsumed && !inUserControl) {
+                        titleBar.forceHitTest(false)
+                    } else {
+                        if (event.type == PointerEventType.Press) {
+                            inUserControl = true
+                        }
+                        if (event.type == PointerEventType.Release) {
+                            inUserControl = false
+                        }
+                        titleBar.forceHitTest(true)
+                    }
+                }
+            }
+        }
+    }
+
+@Composable
+private fun FrameContent(
+    titleBar: TitleBar,
+    modifier: Modifier,
+    title: String,
+    windowIcon: Painter? = null,
+    showTitleInTitleBar: Boolean,
+    showWindowIconInTitleBar: Boolean,
+    titleBarStyle: TitleBarStyle,
+    start: (@Composable () -> Unit)?,
+    end: (@Composable () -> Unit)?,
+    onRequestMinimize: (() -> Unit)?,
+    onRequestToggleMaximize: (() -> Unit)?,
+    onRequestClose: () -> Unit,
+    onWindowIconClicked: (() -> Unit)?,
+) {
+    titleBar.RenderTitleBar(
+        modifier = modifier.fillMaxWidth(),
+        titleBar = titleBar,
+        title = title,
+        windowIcon = windowIcon,
+        showTitle = showTitleInTitleBar,
+        showWindowIcon = showWindowIconInTitleBar,
+        style = titleBarStyle,
+        start = start,
+        end = end,
+        onWindowIconClicked = onWindowIconClicked,
+        onRequestClose = onRequestClose,
+        onRequestMinimize = onRequestMinimize,
+        onRequestToggleMaximize = onRequestToggleMaximize,
+    )
+}
+
+private fun Color.toWindowColorType() =
+    java.awt.Color(
+        red,
+        green,
+        blue,
+    )
+
+@Composable
+fun CustomWindow(
+    state: WindowState,
+    onCloseRequest: () -> Unit,
+    onWindowIconClicked: (() -> Unit)?,
+    resizable: Boolean = true,
+    titleBarStyle: TitleBarStyle,
+    onRequestMinimize: (() -> Unit)? = {
+        state.isMinimized = true
+    },
+    onRequestToggleMaximize: (() -> Unit)? = {
+        if (state.placement == WindowPlacement.Maximized) {
+            state.placement = WindowPlacement.Floating
+        } else {
+            state.placement = WindowPlacement.Maximized
+        }
+    },
+    windowController: WindowController =
+        remember {
+            WindowController()
+        },
+    onKeyEvent: (KeyEvent) -> Boolean = { false },
+    alwaysOnTop: Boolean = false,
+    preventMinimize: Boolean = onRequestMinimize == null,
+    content: @Composable FrameWindowScope.() -> Unit,
+) {
+    val start = windowController.start
+    val end = windowController.end
+    val title = windowController.title.orEmpty()
+    val showTitleInTitleBar = windowController.showTitleInTitleBar
+    val showWindowIconInTitleBar = windowController.showWindowIconInTitleBar
+    val icon = windowController.icon
+
+    val transparent: Boolean
+    val undecorated: Boolean
+    val isAeroSnapSupported = JBR.isWindowDecorationsSupported()
+    if (isAeroSnapSupported) {
+        // we use aero snap
+        transparent = false
+        undecorated = false
+    } else {
+        // we decorate window and add our custom layout
+        transparent = true
+        undecorated = true
+    }
+    Window(
+        state = state,
+        transparent = transparent,
+        undecorated = undecorated,
+        icon = icon,
+        title = title,
+        resizable = resizable,
+        onCloseRequest = onCloseRequest,
+        onKeyEvent = onKeyEvent,
+        alwaysOnTop = alwaysOnTop,
+    ) {
+        val isLight = false // move to style
+        val background = MaterialTheme.colorScheme.background
+        LaunchedEffect(background) {
+            withContext(Dispatchers.Main) {
+                // I set window background fix window edge flickering on window resize
+                window.background =
+                    background
+                        .takeOrElse {
+                            if (isLight) {
+                                Color.White
+                            } else {
+                                Color.Black
+                            }
+                        }.toWindowColorType()
+            }
+        }
+        UiScaledContent {
+            CompositionLocalProvider(
+                LocalWindowController provides windowController,
+                LocalWindowState provides state,
+                LocalWindow provides window,
+                LocalFrameWindowScope provides this,
+            ) {
+                if (preventMinimize) {
+                    PreventMinimize()
+                }
+                CustomWindowFrame(
+                    onRequestMinimize = onRequestMinimize,
+                    onRequestClose = onCloseRequest,
+                    onRequestToggleMaximize = onRequestToggleMaximize,
+                    title = title,
+                    titleBarStyle = titleBarStyle,
+                    showTitleInTitleBar = showTitleInTitleBar,
+                    showWindowIconInTitleBar = showWindowIconInTitleBar,
+                    windowIcon = icon,
+                    background = background,
+                    start = start,
+                    end = end,
+                    onWindowIconClicked = onWindowIconClicked,
+                ) {
+                    ResponsiveBox {
+                        Box(Modifier.clearFocusOnTap()) {
+                            PopUpContainer {
+                                content()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PreventMinimize() {
+    val state = LocalWindowState.current
+    LaunchedEffect(state.isMinimized) {
+        if (state.isMinimized) {
+            state.isMinimized = false
+        }
+    }
+}
+
+private fun Modifier.clearFocusOnTap(): Modifier =
+    composed {
+        val focusManager = LocalFocusManager.current
+        Modifier.pointerInput(Unit) {
+            awaitEachGesture {
+                awaitFirstDown(pass = PointerEventPass.Main)
+                val upEvent = waitForUpOrCancellation(pass = PointerEventPass.Main)
+                if (upEvent != null) {
+                    focusManager.clearFocus()
+                }
+            }
+        }
+    }
+
+private val LocalBottomSheetContainer =
+    compositionLocalOf<MutableMap<Any, @Composable () -> Unit>> { error("not initialized yet") }
+
+@Composable
+private fun PopUpContainer(context: @Composable () -> Unit) {
+    val items =
+        remember {
+            mutableStateMapOf<Any, @Composable () -> Unit>()
+        }
+    CompositionLocalProvider(
+        LocalBottomSheetContainer provides items,
+        content = context,
+    )
+    items.forEach {
+        key(it.key) {
+            it.value()
+        }
+    }
+}
+
+private val LocalWindowState =
+    compositionLocalOf<WindowState> { error("window controller not provided") }
+
+val LocalFrameWindowScope =
+    compositionLocalOf<FrameWindowScope> {
+        error("LocalFrameWindowScope not provided yet")
+    }
+
+private inline fun <Base, T : Base> T.ifThen(
+    condition: Boolean,
+    block: T.() -> Base,
+): Base =
+    if (condition) {
+        this.block()
+    } else {
+        this
+    }
+
+val LocalWindow =
+    staticCompositionLocalOf<Window> {
+        error("CompositionLocal LocalWindow not provided")
+    }

--- a/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/frame/Responsive.kt
+++ b/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/frame/Responsive.kt
@@ -1,0 +1,76 @@
+package io.composeflow.ui.window.frame
+
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.BoxWithConstraintsScope
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ProvidedValue
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+interface ResponsiveSize {
+    val maxHeight: Dp
+    val maxWidth: Dp
+}
+
+@Immutable
+data class WindowSize(
+    override val maxHeight: Dp,
+    override val maxWidth: Dp,
+) : ResponsiveSize
+
+@Immutable
+data class ContainerSize(
+    override val maxHeight: Dp,
+    override val maxWidth: Dp,
+    private val containerName: String,
+) : ResponsiveSize
+
+@Composable
+fun provideContainerSize(
+    maxHeight: Dp,
+    maxWidth: Dp,
+    name: String? = null,
+): ProvidedValue<ContainerSize> =
+    LocalContainerSize provides
+        ContainerSize(
+            maxHeight,
+            maxWidth,
+            name ?: "not specified container",
+        )
+
+@Composable
+fun provideWindowSize(
+    maxHeight: Dp,
+    maxWidth: Dp,
+): ProvidedValue<WindowSize> = LocalWindowSize provides WindowSize(maxHeight, maxWidth)
+
+@Composable
+fun ResponsiveBox(content: @Composable BoxWithConstraintsScope.() -> Unit) {
+    BoxWithConstraints {
+        CompositionLocalProvider(
+            provideContainerSize(maxHeight, maxWidth),
+        ) {
+            content()
+        }
+    }
+}
+
+enum class ResponsiveTarget {
+    Phone,
+    Tablet,
+    Desktop,
+}
+
+@Composable
+fun rememberResponsiveWidth(): ResponsiveTarget =
+    when (LocalContainerSize.current.maxWidth) {
+        in 0.dp..599.dp -> ResponsiveTarget.Phone
+        in 600.dp..1199.dp -> ResponsiveTarget.Tablet
+        else -> ResponsiveTarget.Desktop
+    }
+
+val LocalWindowSize = compositionLocalOf<WindowSize> { error("not initialized") }
+val LocalContainerSize = compositionLocalOf<ContainerSize> { error("not initialized") }

--- a/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/frame/Sizing.kt
+++ b/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/frame/Sizing.kt
@@ -1,0 +1,33 @@
+package io.composeflow.ui.window.frame
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+
+val LocalUiScale = staticCompositionLocalOf<Float?> { null }
+
+/**
+ * put this in every window because Window composable override [LocalDensity]
+ */
+@Composable
+fun UiScaledContent(
+    defaultDensity: Density = LocalDensity.current,
+    uiScale: Float? = LocalUiScale.current,
+    content: @Composable () -> Unit,
+) {
+    val density =
+        remember(uiScale) {
+            if (uiScale == null) {
+                defaultDensity
+            } else {
+                Density(uiScale)
+            }
+        }
+    CompositionLocalProvider(
+        LocalDensity provides density,
+        content,
+    )
+}

--- a/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/titlebar/SystemButtonShared.kt
+++ b/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/titlebar/SystemButtonShared.kt
@@ -1,0 +1,241 @@
+package io.composeflow.ui.window.titlebar
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import io.composeflow.ui.window.SystemButtonType
+import io.composeflow.ui.window.frame.isWindowFocused
+import io.composeflow.ui.window.frame.isWindowMaximized
+import io.composeflow.ui.window.windowButton
+
+@Composable
+private fun SystemButton(
+    onClick: () -> Unit,
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+    background: Color = Color.Transparent,
+    onBackground: Color = MaterialTheme.colorScheme.onBackground,
+    hoveredBackgroundColor: Color = onBackground.copy(alpha = 0.1f),
+    onHoveredBackgroundColor: Color = MaterialTheme.colorScheme.onBackground,
+) {
+    val isFocused = isWindowFocused()
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+    Icon(
+        imageVector = icon,
+        contentDescription = null,
+        tint =
+            animateColorAsState(
+                when {
+                    isHovered -> onHoveredBackgroundColor
+                    else -> onBackground
+                }.copy(
+                    alpha =
+                        if (isFocused || isHovered) {
+                            1f
+                        } else {
+                            0.5f
+                        },
+                ),
+            ).value,
+        modifier =
+            modifier
+                .clickable { onClick() }
+                .background(
+                    animateColorAsState(
+                        when {
+                            isHovered -> hoveredBackgroundColor
+                            else -> background
+                        },
+                    ).value,
+                ).hoverable(interactionSource)
+                .windowButton(),
+    )
+}
+
+@Composable
+internal fun CommonSystemButtons(
+    onRequestClose: () -> Unit,
+    onRequestMinimize: (() -> Unit)?,
+    onToggleMaximize: (() -> Unit)?,
+    buttons: List<SystemButtonType>,
+) {
+    Row(
+        modifier = Modifier.fillMaxHeight().wrapContentHeight(Alignment.Top),
+        verticalAlignment = Alignment.Top,
+    ) {
+        buttons.forEach {
+            when (it) {
+                SystemButtonType.Close -> {
+                    SystemButton(
+                        onClick = onRequestClose,
+                        background = Color.Transparent,
+                        hoveredBackgroundColor = Color(0xFFc42b1c),
+                        icon = Icons.Default.Close,
+                    )
+                }
+
+                SystemButtonType.Minimize -> {
+                    onRequestMinimize?.let {
+                        SystemButton(
+                            icon = IconMinimize,
+                            onClick = onRequestMinimize,
+                        )
+                    }
+                }
+
+                SystemButtonType.Maximize -> {
+                    onToggleMaximize?.let {
+                        SystemButton(
+                            icon =
+                                if (isWindowMaximized()) {
+                                    IconRestore
+                                } else {
+                                    IconMaximize
+                                },
+                            onClick = onToggleMaximize,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private val IconMaximize: ImageVector
+    get() {
+        if (_IconMaximize != null) {
+            return _IconMaximize!!
+        }
+        _IconMaximize =
+            ImageVector
+                .Builder(
+                    name = "IconMaximize",
+                    defaultWidth = 16.dp,
+                    defaultHeight = 16.dp,
+                    viewportWidth = 16f,
+                    viewportHeight = 16f,
+                ).apply {
+                    path(
+                        stroke = SolidColor(Color(0xFFCED0D6)),
+                        strokeLineWidth = 1f,
+                    ) {
+                        moveTo(3.5f, 3.5f)
+                        horizontalLineToRelative(9f)
+                        verticalLineToRelative(9f)
+                        horizontalLineToRelative(-9f)
+                        close()
+                    }
+                }.build()
+
+        return _IconMaximize!!
+    }
+
+@Suppress("ObjectPropertyName")
+private var _IconMaximize: ImageVector? = null
+
+private val IconRestore: ImageVector
+    get() {
+        if (_IconRestore != null) {
+            return _IconRestore!!
+        }
+        _IconRestore =
+            ImageVector
+                .Builder(
+                    name = "IconRestore",
+                    defaultWidth = 16.dp,
+                    defaultHeight = 16.dp,
+                    viewportWidth = 16f,
+                    viewportHeight = 16f,
+                ).apply {
+                    path(
+                        fill = SolidColor(Color(0xFFCED0D6)),
+                        pathFillType = PathFillType.EvenOdd,
+                    ) {
+                        moveTo(5f, 3f)
+                        horizontalLineTo(13f)
+                        verticalLineTo(11f)
+                        horizontalLineTo(10f)
+                        verticalLineTo(10f)
+                        horizontalLineTo(12f)
+                        verticalLineTo(4f)
+                        horizontalLineTo(6f)
+                        verticalLineTo(6f)
+                        horizontalLineTo(5f)
+                        verticalLineTo(3f)
+                        close()
+                    }
+                    path(
+                        fill = SolidColor(Color(0xFFCED0D6)),
+                        pathFillType = PathFillType.EvenOdd,
+                    ) {
+                        moveTo(11f, 5f)
+                        horizontalLineTo(3f)
+                        verticalLineTo(13f)
+                        horizontalLineTo(11f)
+                        verticalLineTo(5f)
+                        close()
+                        moveTo(10f, 6f)
+                        horizontalLineTo(4f)
+                        verticalLineTo(12f)
+                        horizontalLineTo(10f)
+                        verticalLineTo(6f)
+                        close()
+                    }
+                }.build()
+
+        return _IconRestore!!
+    }
+
+@Suppress("ObjectPropertyName")
+private var _IconRestore: ImageVector? = null
+
+private val IconMinimize: ImageVector
+    get() {
+        if (_IconMinimize != null) {
+            return _IconMinimize!!
+        }
+        _IconMinimize =
+            ImageVector
+                .Builder(
+                    name = "IconMinimize",
+                    defaultWidth = 16.dp,
+                    defaultHeight = 16.dp,
+                    viewportWidth = 16f,
+                    viewportHeight = 16f,
+                ).apply {
+                    path(fill = SolidColor(Color(0xFFCED0D6))) {
+                        moveTo(3f, 8f)
+                        horizontalLineToRelative(10f)
+                        verticalLineToRelative(1f)
+                        horizontalLineToRelative(-10f)
+                        close()
+                    }
+                }.build()
+
+        return _IconMinimize!!
+    }
+
+@Suppress("ObjectPropertyName")
+private var _IconMinimize: ImageVector? = null

--- a/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/titlebar/linux/LinuxSystemButtonsProvider.kt
+++ b/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/titlebar/linux/LinuxSystemButtonsProvider.kt
@@ -1,0 +1,126 @@
+package io.composeflow.ui.window.titlebar.linux
+
+import io.composeflow.ui.window.SystemButtonType
+import io.composeflow.ui.window.SystemButtonsPosition
+import io.composeflow.ui.window.SystemButtonsPositionProvider
+import java.io.File
+
+object LinuxSystemButtonsProvider : SystemButtonsPositionProvider {
+    override fun getPositions(): SystemButtonsPosition? =
+        runCatching {
+            getSystemButtonLayout()
+        }.getOrNull()
+
+    private fun getSystemButtonLayout(): SystemButtonsPosition? {
+        val desktop =
+            System.getenv("XDG_CURRENT_DESKTOP")?.lowercase() ?: System
+                .getenv("DESKTOP_SESSION")
+                ?.lowercase() ?: "unknow"
+
+        return when {
+            "gnome" in desktop ->
+                parseColonLayout(
+                    runCommand(
+                        "gsettings",
+                        "get",
+                        "org.gnome.desktop.wm.preferences",
+                        "button-layout",
+                    ),
+                )
+
+            "mate" in desktop ->
+                parseColonLayout(
+                    runCommand(
+                        "gsettings",
+                        "get",
+                        "org.mate.Marco.general",
+                        "button-layout",
+                    ),
+                )
+
+            "xfce" in desktop ->
+                parsePipeLayout(
+                    runCommand(
+                        "xfconf-query",
+                        "-c",
+                        "xfwm4",
+                        "-p",
+                        "/general/button_layout",
+                    ),
+                )
+
+            "kde" in desktop ->
+                parseKDELayout(
+                    File(
+                        System.getProperty("user.home"),
+                        ".config/kwinrc",
+                    ),
+                )
+
+            else -> null
+        }?.takeIf { it.buttons.isNotEmpty() }
+    }
+
+    // For GNOME / MATE → colon-separated layout
+    private fun parseColonLayout(layoutRaw: String?): SystemButtonsPosition? {
+        val layout = layoutRaw?.removeSurrounding("'", "'")?.trim() ?: return null
+        val (left, right) =
+            layout.split(":", limit = 2).map { it.trim() + "," }.let {
+                parseButtons(it.getOrNull(0).orEmpty()) to parseButtons(it.getOrNull(1).orEmpty())
+            }
+
+        return when {
+            left.isNotEmpty() -> SystemButtonsPosition(left, isLeft = true)
+            right.isNotEmpty() -> SystemButtonsPosition(right, isLeft = false)
+            else -> null
+        }
+    }
+
+    // For XFCE → pipe-separated layout
+    private fun parsePipeLayout(layoutRaw: String?): SystemButtonsPosition? {
+        val parts = layoutRaw?.split("|")?.map { it.trim() } ?: return null
+        return when {
+            parts.isNotEmpty() && parts[0].isNotEmpty() -> {
+                SystemButtonsPosition(parseButtons(parts[0]), isLeft = true)
+            }
+
+            parts.size > 1 && parts[1].isNotEmpty() -> {
+                SystemButtonsPosition(parseButtons(parts[0]), isLeft = true)
+            }
+
+            else -> null
+        }
+    }
+
+    // For KDE → parse kwinrc file
+    private fun parseKDELayout(file: File): SystemButtonsPosition? {
+        if (!file.exists()) return null
+        val lines = file.readLines()
+        val left = lines.find { it.startsWith("ButtonsOnLeft=") }?.substringAfter("=")?.trim()
+        val right = lines.find { it.startsWith("ButtonsOnRight=") }?.substringAfter("=")?.trim()
+
+        return when {
+            !left.isNullOrEmpty() -> SystemButtonsPosition(parseButtons(left), isLeft = true)
+            !right.isNullOrEmpty() -> SystemButtonsPosition(parseButtons(right), isLeft = false)
+            else -> null
+        }
+    }
+
+    private fun parseButtons(raw: String): List<SystemButtonType> =
+        raw.split(",", "|", " ").mapNotNull {
+            when (it.lowercase()) {
+                "close" -> SystemButtonType.Close
+                "minimize" -> SystemButtonType.Minimize
+                "maximize" -> SystemButtonType.Maximize
+                else -> null
+            }
+        }
+
+    private fun runCommand(vararg args: String): String? =
+        try {
+            val process = ProcessBuilder(*args).redirectErrorStream(true).start()
+            process.inputStream.reader().use { it.readText().trim() }
+        } catch (_: Exception) {
+            null
+        }
+}

--- a/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/titlebar/linux/LinuxTitleBar.kt
+++ b/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/titlebar/linux/LinuxTitleBar.kt
@@ -1,0 +1,96 @@
+package io.composeflow.ui.window.titlebar.linux
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import io.composeflow.ui.window.CommonRenderTitleBar
+import io.composeflow.ui.window.CommonTitleBarContent
+import io.composeflow.ui.window.SystemButtonType
+import io.composeflow.ui.window.SystemButtonsPosition
+import io.composeflow.ui.window.TitleBar
+import io.composeflow.ui.window.styling.TitleBarStyle
+import io.composeflow.ui.window.titlebar.CommonSystemButtons
+
+object LinuxTitleBar : TitleBar {
+    override val systemButtonsPosition: SystemButtonsPosition by lazy {
+        LinuxSystemButtonsProvider.getPositions() ?: SystemButtonsPosition(
+            buttons =
+                listOf(
+                    SystemButtonType.Minimize,
+                    SystemButtonType.Maximize,
+                    SystemButtonType.Close,
+                ),
+            isLeft = false,
+        )
+    }
+
+    @Composable
+    override fun RenderSystemButtons(
+        onRequestClose: () -> Unit,
+        onRequestMinimize: (() -> Unit)?,
+        onToggleMaximize: (() -> Unit)?,
+    ) {
+        CommonSystemButtons(
+            onRequestClose = onRequestClose,
+            onRequestMinimize = onRequestMinimize,
+            onToggleMaximize = onToggleMaximize,
+            buttons = systemButtonsPosition.buttons,
+        )
+    }
+
+    @Composable
+    override fun RenderTitleBarContent(
+        title: String,
+        modifier: Modifier,
+        windowIcon: Painter?,
+        showTitle: Boolean,
+        showWindowIcon: Boolean,
+        start: @Composable (() -> Unit)?,
+        end: @Composable (() -> Unit)?,
+        onWindowIconClicked: (() -> Unit)?,
+    ) {
+        CommonTitleBarContent(
+            modifier = modifier,
+            title = title,
+            windowIcon = windowIcon,
+            showTitle = showTitle,
+            showWindowIcon = showWindowIcon,
+            start = start,
+            end = end,
+            onWindowIconClicked = onWindowIconClicked,
+        )
+    }
+
+    @Composable
+    override fun RenderTitleBar(
+        modifier: Modifier,
+        titleBar: TitleBar,
+        title: String,
+        windowIcon: Painter?,
+        showTitle: Boolean,
+        showWindowIcon: Boolean,
+        style: TitleBarStyle,
+        start: @Composable (() -> Unit)?,
+        end: @Composable (() -> Unit)?,
+        onWindowIconClicked: (() -> Unit)?,
+        onRequestClose: () -> Unit,
+        onRequestMinimize: (() -> Unit)?,
+        onRequestToggleMaximize: (() -> Unit)?,
+    ) {
+        CommonRenderTitleBar(
+            modifier = modifier,
+            titleBar = titleBar,
+            title = title,
+            windowIcon = windowIcon,
+            style = style,
+            showTitle = showTitle,
+            showWindowIcon = showWindowIcon,
+            start = start,
+            end = end,
+            onWindowIconClicked = onWindowIconClicked,
+            onRequestClose = onRequestClose,
+            onRequestMinimize = onRequestMinimize,
+            onRequestToggleMaximize = onRequestToggleMaximize,
+        )
+    }
+}

--- a/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/titlebar/mac/MacTitleBar.kt
+++ b/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/titlebar/mac/MacTitleBar.kt
@@ -1,0 +1,94 @@
+package io.composeflow.ui.window.titlebar.mac
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import io.composeflow.ui.window.CommonRenderTitleBar
+import io.composeflow.ui.window.CommonTitleBarContent
+import io.composeflow.ui.window.SystemButtonType
+import io.composeflow.ui.window.SystemButtonsPosition
+import io.composeflow.ui.window.TitleBar
+import io.composeflow.ui.window.styling.TitleBarStyle
+
+object MacTitleBar : TitleBar {
+    override val systemButtonsPosition: SystemButtonsPosition =
+        SystemButtonsPosition(
+            buttons =
+                listOf(
+                    SystemButtonType.Close,
+                    SystemButtonType.Minimize,
+                    SystemButtonType.Maximize,
+                ),
+            isLeft = true,
+        )
+
+    @Composable
+    override fun RenderSystemButtons(
+        onRequestClose: () -> Unit,
+        onRequestMinimize: (() -> Unit)?,
+        onToggleMaximize: (() -> Unit)?,
+    ) {
+        MacOSSystemButtons(
+            onRequestClose = onRequestClose,
+            onRequestMinimize = onRequestMinimize,
+            onToggleMaximize = onToggleMaximize,
+            buttons = systemButtonsPosition.buttons,
+        )
+    }
+
+    @Composable
+    override fun RenderTitleBarContent(
+        title: String,
+        modifier: Modifier,
+        windowIcon: Painter?,
+        showTitle: Boolean,
+        showWindowIcon: Boolean,
+        start: @Composable (() -> Unit)?,
+        end: @Composable (() -> Unit)?,
+        onWindowIconClicked: (() -> Unit)?,
+    ) {
+        CommonTitleBarContent(
+            modifier = modifier,
+            title = title,
+            windowIcon = windowIcon,
+            showTitle = showTitle,
+            showWindowIcon = showWindowIcon,
+            start = start,
+            end = end,
+            onWindowIconClicked = onWindowIconClicked,
+        )
+    }
+
+    @Composable
+    override fun RenderTitleBar(
+        modifier: Modifier,
+        titleBar: TitleBar,
+        title: String,
+        windowIcon: Painter?,
+        showTitle: Boolean,
+        showWindowIcon: Boolean,
+        style: TitleBarStyle,
+        start: @Composable (() -> Unit)?,
+        end: @Composable (() -> Unit)?,
+        onWindowIconClicked: (() -> Unit)?,
+        onRequestClose: () -> Unit,
+        onRequestMinimize: (() -> Unit)?,
+        onRequestToggleMaximize: (() -> Unit)?,
+    ) {
+        CommonRenderTitleBar(
+            modifier = modifier,
+            titleBar = titleBar,
+            title = title,
+            windowIcon = windowIcon,
+            style = style,
+            showTitle = showTitle,
+            showWindowIcon = showWindowIcon,
+            start = start,
+            end = end,
+            onWindowIconClicked = onWindowIconClicked,
+            onRequestClose = onRequestClose,
+            onRequestMinimize = onRequestMinimize,
+            onRequestToggleMaximize = onRequestToggleMaximize,
+        )
+    }
+}

--- a/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/titlebar/mac/SystemButtons.kt
+++ b/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/titlebar/mac/SystemButtons.kt
@@ -1,0 +1,229 @@
+package io.composeflow.ui.window.titlebar.mac
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.onClick
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+import io.composeflow.ui.window.SystemButtonType
+import io.composeflow.ui.window.frame.isWindowFocused
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun SystemButton(
+    onClick: () -> Unit,
+    icon: ImageVector,
+    isUserInThisArea: Boolean,
+    hoveredBackgroundColor: Color,
+    modifier: Modifier = Modifier,
+    unfocusedBackgroundColor: Color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.2f),
+) {
+    val isWindowFocused = isWindowFocused()
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+
+    Box(
+        modifier =
+            modifier
+                .hoverable(interactionSource)
+                .onClick { onClick() }
+                .fillMaxHeight()
+                .wrapContentHeight()
+                .padding(horizontal = 6.dp)
+                .background(
+                    animateColorAsState(
+                        when {
+                            !isWindowFocused -> unfocusedBackgroundColor
+                            isHovered -> hoveredBackgroundColor.copy(alpha = 0.1f)
+                            else -> hoveredBackgroundColor
+                        },
+                    ).value,
+                    CircleShape,
+                ).requiredSize(12.dp),
+    ) {
+        if (isUserInThisArea && isWindowFocused) {
+            Icon(
+                imageVector = icon,
+                tint = Color.Black,
+                modifier = Modifier.align(Alignment.Center).size(10.dp),
+                contentDescription = null,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun MacOSSystemButtons(
+    onRequestClose: () -> Unit,
+    onRequestMinimize: (() -> Unit)?,
+    onToggleMaximize: (() -> Unit)?,
+    buttons: List<SystemButtonType>,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+
+    Row(
+        modifier =
+            Modifier
+                .padding(horizontal = 6.dp)
+                .hoverable(interactionSource)
+                .fillMaxHeight()
+                .wrapContentHeight(Alignment.Top),
+        verticalAlignment = Alignment.Top,
+    ) {
+        buttons.forEach {
+            when (it) {
+                SystemButtonType.Close -> {
+                    SystemButton(
+                        onClick = onRequestClose,
+                        hoveredBackgroundColor = Color(0xFFFF5F57),
+                        icon = Icons.Default.Close,
+                        isUserInThisArea = isHovered,
+                    )
+                }
+
+                SystemButtonType.Minimize -> {
+                    onRequestMinimize?.let {
+                        SystemButton(
+                            icon = IconMinimize,
+                            onClick = onRequestMinimize,
+                            isUserInThisArea = isHovered,
+                            hoveredBackgroundColor = Color(0xFFFFBD2E),
+                        )
+                    }
+                }
+
+                SystemButtonType.Maximize -> {
+                    onToggleMaximize?.let {
+                        SystemButton(
+                            icon = IconMaximize,
+                            onClick = onToggleMaximize,
+                            isUserInThisArea = isHovered,
+                            hoveredBackgroundColor = Color(0xFF28C840),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private val IconMaximize: ImageVector
+    get() {
+        if (_IconMaximize != null) {
+            return _IconMaximize!!
+        }
+        _IconMaximize =
+            ImageVector
+                .Builder(
+                    name = "IconMaximize",
+                    defaultWidth = 256.dp,
+                    defaultHeight = 256.dp,
+                    viewportWidth = 256f,
+                    viewportHeight = 256f,
+                ).apply {
+                    path(
+                        fill = SolidColor(Color(0xFF74DA74)),
+                        fillAlpha = 0.12f,
+                        strokeAlpha = 0.12f,
+                        pathFillType = PathFillType.EvenOdd,
+                    ) {
+                        moveToRelative(20.5f, 100.5f)
+                        curveToRelative(-1.41f, 9.61f, -2.41f, 19.27f, -3f, 29f)
+                        curveToRelative(1.02f, 11.43f, 2.68f, 22.76f, 5f, 34f)
+                        curveToRelative(-6.01f, -17.48f, -7.51f, -35.48f, -4.5f, -54f)
+                        curveToRelative(0.41f, -3.24f, 1.24f, -6.24f, 2.5f, -9f)
+                        close()
+                    }
+                    path(
+                        fill = SolidColor(Color(0xFF038601)),
+                        pathFillType = PathFillType.EvenOdd,
+                    ) {
+                        moveToRelative(75.5f, 102.5f)
+                        curveToRelative(20.69f, 21.69f, 42.02f, 42.69f, 64f, 63f)
+                        curveToRelative(5.33f, 5.67f, 10.67f, 11.33f, 16f, 17f)
+                        curveToRelative(-22.5f, 1.16f, -45.16f, 1.33f, -68f, 0.5f)
+                        curveToRelative(-1.4f, -1.27f, -3.07f, -1.77f, -5f, -1.5f)
+                        curveToRelative(-4.09f, -3.76f, -6.59f, -8.43f, -7.5f, -14f)
+                        curveToRelative(-0.33f, 0.33f, -0.67f, 0.67f, -1f, 1f)
+                        curveToRelative(-0.17f, -11f, -0.33f, -22f, -0.5f, -33f)
+                        curveToRelative(0f, -11.35f, 0.67f, -22.35f, 2f, -33f)
+                        close()
+                    }
+                    path(
+                        fill = SolidColor(Color(0xFF048702)),
+                        pathFillType = PathFillType.EvenOdd,
+                    ) {
+                        moveToRelative(170.5f, 73.5f)
+                        curveToRelative(4.88f, 1.87f, 8.54f, 5.21f, 11f, 10f)
+                        curveToRelative(0.5f, 1.98f, 1f, 3.98f, 1.5f, 6f)
+                        curveToRelative(0.83f, 22.01f, 0.67f, 44.01f, -0.5f, 66f)
+                        curveToRelative(-1.35f, -1.02f, -2.69f, -2.02f, -4f, -3f)
+                        curveToRelative(-2.83f, -3f, -5.5f, -6.17f, -8f, -9.5f)
+                        curveToRelative(-22.5f, -20.67f, -44.5f, -41.84f, -66f, -63.5f)
+                        curveToRelative(-0.33f, -0.67f, -0.67f, -1.33f, -1f, -2f)
+                        curveToRelative(-0.79f, -1.29f, -1.79f, -2.46f, -3f, -3.5f)
+                        curveToRelative(23.33f, -0.5f, 46.66f, -0.67f, 70f, -0.5f)
+                        close()
+                    }
+                }.build()
+
+        return _IconMaximize!!
+    }
+
+@Suppress("ObjectPropertyName")
+private var _IconMaximize: ImageVector? = null
+
+private val IconMinimize: ImageVector
+    get() {
+        if (_IconMinimize != null) {
+            return _IconMinimize!!
+        }
+        _IconMinimize =
+            ImageVector
+                .Builder(
+                    name = "IconMinimize",
+                    defaultWidth = 16.dp,
+                    defaultHeight = 16.dp,
+                    viewportWidth = 16f,
+                    viewportHeight = 16f,
+                ).apply {
+                    path(fill = SolidColor(Color(0xFFCED0D6))) {
+                        moveTo(3f, 8f)
+                        horizontalLineToRelative(10f)
+                        verticalLineToRelative(1f)
+                        horizontalLineToRelative(-10f)
+                        close()
+                    }
+                }.build()
+
+        return _IconMinimize!!
+    }
+
+@Suppress("ObjectPropertyName")
+private var _IconMinimize: ImageVector? = null

--- a/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/titlebar/windows/WindowsTitleBar.kt
+++ b/core/ui/src/jvmMain/kotlin/io/composeflow/ui/window/titlebar/windows/WindowsTitleBar.kt
@@ -1,0 +1,121 @@
+package io.composeflow.ui.window.titlebar.windows
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.Density
+import io.composeflow.ui.window.CommonRenderTitleBar
+import io.composeflow.ui.window.CommonTitleBarContent
+import io.composeflow.ui.window.SystemButtonType
+import io.composeflow.ui.window.SystemButtonsPosition
+import io.composeflow.ui.window.TitleBar
+import io.composeflow.ui.window.styling.TitleBarStyle
+import io.composeflow.ui.window.titlebar.CommonSystemButtons
+import java.awt.GraphicsConfiguration
+import java.awt.GraphicsEnvironment
+
+object WindowsTitleBar : TitleBar {
+    override val systemButtonsPosition: SystemButtonsPosition =
+        SystemButtonsPosition(
+            buttons =
+                listOf(
+                    SystemButtonType.Minimize,
+                    SystemButtonType.Maximize,
+                    SystemButtonType.Close,
+                ),
+            isLeft = false,
+        )
+
+    @Composable
+    override fun RenderSystemButtons(
+        onRequestClose: () -> Unit,
+        onRequestMinimize: (() -> Unit)?,
+        onToggleMaximize: (() -> Unit)?,
+    ) {
+        CommonSystemButtons(
+            onRequestClose = onRequestClose,
+            onRequestMinimize = onRequestMinimize,
+            onToggleMaximize = onToggleMaximize,
+            buttons = systemButtonsPosition.buttons,
+        )
+    }
+
+    @Composable
+    override fun RenderTitleBarContent(
+        title: String,
+        modifier: Modifier,
+        windowIcon: Painter?,
+        showTitle: Boolean,
+        showWindowIcon: Boolean,
+        start: @Composable (() -> Unit)?,
+        end: @Composable (() -> Unit)?,
+        onWindowIconClicked: (() -> Unit)?,
+    ) {
+        CommonTitleBarContent(
+            modifier = modifier,
+            title = title,
+            windowIcon = windowIcon,
+            showTitle = showTitle,
+            showWindowIcon = showWindowIcon,
+            start = start,
+            end = end,
+            onWindowIconClicked = onWindowIconClicked,
+        )
+    }
+
+    @Composable
+    override fun RenderTitleBar(
+        modifier: Modifier,
+        titleBar: TitleBar,
+        title: String,
+        windowIcon: Painter?,
+        showTitle: Boolean,
+        showWindowIcon: Boolean,
+        style: TitleBarStyle,
+        start: @Composable (() -> Unit)?,
+        end: @Composable (() -> Unit)?,
+        onWindowIconClicked: (() -> Unit)?,
+        onRequestClose: () -> Unit,
+        onRequestMinimize: (() -> Unit)?,
+        onRequestToggleMaximize: (() -> Unit)?,
+    ) {
+        CommonRenderTitleBar(
+            modifier = modifier,
+            titleBar = titleBar,
+            title = title,
+            windowIcon = windowIcon,
+            style = style,
+            showTitle = showTitle,
+            showWindowIcon = showWindowIcon,
+            start = start,
+            end = end,
+            onWindowIconClicked = onWindowIconClicked,
+            onRequestClose = onRequestClose,
+            onRequestMinimize = onRequestMinimize,
+            onRequestToggleMaximize = onRequestToggleMaximize,
+        )
+    }
+}
+
+val GlobalDensity
+    get() =
+        GraphicsEnvironment
+            .getLocalGraphicsEnvironment()
+            .defaultScreenDevice
+            .defaultConfiguration
+            .density
+
+val GraphicsConfiguration.density: Density
+    get() =
+        Density(
+            defaultTransform.scaleX.toFloat(),
+            fontScale = 1f,
+        )
+
+fun Float.applyUiScale(
+    userUiScale: Float?,
+    systemUiScale: Float = GlobalDensity.density,
+): Float {
+    if (userUiScale == null) return this
+    return (this * userUiScale / systemUiScale)
+}

--- a/core/ui/src/wasmJsMain/kotlin/io/composeflow/ui/window/CustomWindow.wasmJs.kt
+++ b/core/ui/src/wasmJsMain/kotlin/io/composeflow/ui/window/CustomWindow.wasmJs.kt
@@ -1,0 +1,86 @@
+package io.composeflow.ui.window
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.KeyEvent
+import io.composeflow.ui.window.styling.TitleBarStyle
+
+@Composable
+actual fun ComposeFlowWindow(
+    windowController: WindowController,
+    titleBarStyle: TitleBarStyle,
+    resizable: Boolean,
+    onWindowIconClicked: (() -> Unit)?,
+    onCloseRequest: () -> Unit,
+    onRequestMinimize: (() -> Unit)?,
+    onRequestToggleMaximize: (() -> Unit)?,
+    onKeyEvent: (KeyEvent) -> Boolean,
+    alwaysOnTop: Boolean,
+    preventMinimize: Boolean,
+    content: @Composable (() -> Unit),
+) {
+    CustomWindowImpl(
+        onCloseRequest = onCloseRequest,
+        windowController = windowController,
+        titleBarStyle = titleBarStyle,
+        onRequestMinimize = onRequestMinimize,
+        onRequestToggleMaximize = onRequestToggleMaximize,
+        onWindowIconClicked = onWindowIconClicked,
+        content = content,
+    )
+}
+
+@Composable
+private fun CustomWindowImpl(
+    onCloseRequest: () -> Unit,
+    windowController: WindowController,
+    titleBarStyle: TitleBarStyle,
+    onWindowIconClicked: (() -> Unit)?,
+    onRequestMinimize: (() -> Unit)?,
+    onRequestToggleMaximize: (() -> Unit)?,
+    content: @Composable (() -> Unit),
+) {
+    val titleBar = TitleBar.getPlatformTitleBar()
+    val start = windowController.start
+    val end = windowController.end
+    val title = windowController.title.orEmpty()
+    val icon = windowController.icon
+    val showTitleInTitleBar = windowController.showTitleInTitleBar
+    val showWindowIcon = windowController.showWindowIconInTitleBar
+
+    CompositionLocalProvider(
+        LocalWindowController provides windowController,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background),
+        ) {
+            titleBar.RenderTitleBar(
+                modifier =
+                    Modifier
+                        .fillMaxWidth(),
+                titleBar = titleBar,
+                title = title,
+                windowIcon = icon,
+                showTitle = showTitleInTitleBar,
+                showWindowIcon = showWindowIcon,
+                style = titleBarStyle,
+                start = start,
+                end = end,
+                onWindowIconClicked = onWindowIconClicked,
+                onRequestClose = onCloseRequest,
+                onRequestMinimize = onRequestMinimize,
+                onRequestToggleMaximize = onRequestToggleMaximize,
+            )
+            content()
+        }
+    }
+}

--- a/core/ui/src/wasmJsMain/kotlin/io/composeflow/ui/window/TitleBar.wasmJs.kt
+++ b/core/ui/src/wasmJsMain/kotlin/io/composeflow/ui/window/TitleBar.wasmJs.kt
@@ -1,0 +1,76 @@
+package io.composeflow.ui.window
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import io.composeflow.ui.window.styling.TitleBarStyle
+
+object WasmJsTitleBar : TitleBar {
+    override val systemButtonsPosition: SystemButtonsPosition
+        get() = SystemButtonsPosition(buttons = emptyList(), isLeft = false)
+
+    @Composable
+    override fun RenderSystemButtons(
+        onRequestClose: () -> Unit,
+        onRequestMinimize: (() -> Unit)?,
+        onToggleMaximize: (() -> Unit)?,
+    ) { }
+
+    @Composable
+    override fun RenderTitleBarContent(
+        title: String,
+        modifier: Modifier,
+        windowIcon: Painter?,
+        showTitle: Boolean,
+        showWindowIcon: Boolean,
+        start: @Composable (() -> Unit)?,
+        end: @Composable (() -> Unit)?,
+        onWindowIconClicked: (() -> Unit)?,
+    ) {
+        CommonTitleBarContent(
+            modifier = modifier,
+            title = title,
+            windowIcon = windowIcon,
+            showTitle = showTitle,
+            showWindowIcon = showWindowIcon,
+            start = start,
+            end = end,
+            onWindowIconClicked = onWindowIconClicked,
+        )
+    }
+
+    @Composable
+    override fun RenderTitleBar(
+        modifier: Modifier,
+        titleBar: TitleBar,
+        title: String,
+        windowIcon: Painter?,
+        showTitle: Boolean,
+        showWindowIcon: Boolean,
+        style: TitleBarStyle,
+        start: @Composable (() -> Unit)?,
+        end: @Composable (() -> Unit)?,
+        onWindowIconClicked: (() -> Unit)?,
+        onRequestClose: () -> Unit,
+        onRequestMinimize: (() -> Unit)?,
+        onRequestToggleMaximize: (() -> Unit)?,
+    ) {
+        CommonRenderTitleBar(
+            modifier = modifier,
+            titleBar = titleBar,
+            title = title,
+            windowIcon = windowIcon,
+            style = style,
+            showTitle = showTitle,
+            showWindowIcon = showWindowIcon,
+            start = start,
+            end = end,
+            onWindowIconClicked = onWindowIconClicked,
+            onRequestClose = onRequestClose,
+            onRequestMinimize = onRequestMinimize,
+            onRequestToggleMaximize = onRequestToggleMaximize,
+        )
+    }
+}
+
+actual fun TitleBar.Companion.getPlatformTitleBar(): TitleBar = WasmJsTitleBar

--- a/desktopApp/src/jvmMain/kotlin/io/composeflow/TitleBarView.kt
+++ b/desktopApp/src/jvmMain/kotlin/io/composeflow/TitleBarView.kt
@@ -1,82 +1,63 @@
 package io.composeflow
 
-import androidx.compose.foundation.background
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.unit.dp
-import io.composeflow.ui.jewel.TitleBarContent
+import io.composeflow.custom.ComposeFlowIcons
+import io.composeflow.custom.composeflowicons.ComposeFlowLogo
 import io.composeflow.ui.modifier.hoverIconClickable
-import org.jetbrains.jewel.ui.component.Icon
-import org.jetbrains.jewel.ui.component.Text
-import org.jetbrains.jewel.ui.painter.hints.Size
-import org.jetbrains.jewel.ui.painter.rememberResourcePainterProvider
-import org.jetbrains.jewel.window.DecoratedWindowScope
-import org.jetbrains.jewel.window.TitleBar
-import org.jetbrains.jewel.window.newFullscreenControls
 
 @Composable
-fun DecoratedWindowScope.TitleBarView(
+fun TitleBarView(
+    title: String,
     onComposeFlowLogoClicked: () -> Unit,
-    titleBarLeftContent: TitleBarContent,
-    titleBarRightContent: TitleBarContent,
+    titleBarLeftContent: @Composable () -> Unit,
+    titleBarRightContent: @Composable () -> Unit,
 ) {
-    TitleBar(
-        Modifier.newFullscreenControls(newControls = true),
-        gradientStartColor = Color(0xFFB0C6FF),
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth(),
     ) {
-        Row(
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth(),
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier =
+                Modifier
+                    .clip(RoundedCornerShape(4.dp))
+                    .clickable {
+                        onComposeFlowLogoClicked()
+                    }.hoverIconClickable(),
         ) {
-            val painterProvider =
-                rememberResourcePainterProvider(
-                    "ic_composeflow_logo.svg",
-                    Icons::class.java,
-                )
-            val painter by painterProvider.getPainter(
-                Size(18),
+            Image(
+                painter = rememberVectorPainter(ComposeFlowIcons.ComposeFlowLogo),
+                contentDescription = "icon",
+                modifier = Modifier.size(36.dp),
             )
-            Spacer(modifier = Modifier.width(88.dp))
+        }
+        Row(modifier = Modifier.weight(1f)) {
+            titleBarLeftContent()
+        }
+        Text(
+            text = title,
+            color = MaterialTheme.colorScheme.onBackground,
+            style = MaterialTheme.typography.bodyMedium,
+        )
 
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier =
-                    Modifier
-                        .background(
-                            color = Color.White,
-                            shape =
-                                androidx.compose.foundation.shape
-                                    .RoundedCornerShape(4.dp),
-                        ).clickable {
-                            onComposeFlowLogoClicked()
-                        }.hoverIconClickable(),
-            ) {
-                Icon(
-                    painter = painter,
-                    "icon",
-                    modifier = Modifier.padding(4.dp),
-                )
-            }
-            Row(modifier = Modifier.weight(1f)) {
-                titleBarLeftContent()
-            }
-            Text(title)
-            Row(modifier = Modifier.weight(1f)) {
-                titleBarRightContent()
-            }
+        Row(modifier = Modifier.weight(1f)) {
+            titleBarRightContent()
         }
     }
 }

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ProjectEditorView.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ProjectEditorView.kt
@@ -34,6 +34,7 @@ import io.composeflow.ui.statusbar.StatusBar
 import io.composeflow.ui.statusbar.StatusBarViewModel
 import io.composeflow.ui.toolbar.LeftToolbar
 import io.composeflow.ui.toolbar.RightToolbar
+import io.composeflow.ui.toolbar.ToolbarViewModel
 import moe.tlaster.precompose.navigation.rememberNavigator
 import moe.tlaster.precompose.viewmodel.viewModel
 
@@ -94,6 +95,15 @@ fun ProjectEditorContent(
     Surface(
         modifier = aiChatToggleVisibilityModifier,
     ) {
+        val toolbarViewModel =
+            viewModel(
+                modelClass = ToolbarViewModel::class,
+                keys = listOf(firebaseIdToken?.user_id ?: "anonymous"),
+            ) {
+                ToolbarViewModel(
+                    firebaseIdTokenArg = firebaseIdToken,
+                )
+            }
         val statusBarViewModel =
             viewModel(modelClass = StatusBarViewModel::class) {
                 StatusBarViewModel()
@@ -114,7 +124,7 @@ fun ProjectEditorContent(
                     }
                     onTitleBarRightContentSet {
                         RightToolbar(
-                            firebaseIdToken = firebaseIdToken,
+                            viewModel = toolbarViewModel,
                             projectFileName = projectId,
                             onStatusBarUiStateChanged = statusBarViewModel::onStatusBarUiStateChanged,
                             statusBarUiState = statusBarUiState,

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/toolbar/IssueBadge.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/toolbar/IssueBadge.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -43,12 +44,12 @@ import io.composeflow.model.project.issue.DestinationContext
 import io.composeflow.model.project.issue.NavigatableDestination
 import io.composeflow.model.project.issue.TrackableIssue
 import io.composeflow.no_issues_found_message
+import io.composeflow.ui.common.onSurfaceLight
 import io.composeflow.ui.icon.ComposeFlowIcon
 import io.composeflow.ui.modifier.hoverIconClickable
 import kotlinx.coroutines.launch
 import moe.tlaster.precompose.navigation.Navigator
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.jewel.ui.component.Text
 
 private val ValidContainerColor = Color(0xFF5B8657)
 private val ErrorContainerColor = Color(0xFFA84E4B)
@@ -149,7 +150,7 @@ private fun IssuesPanel(
                         Text(
                             stringResource(Res.string.no_issues_found_message) + "  \uD83D\uDE80",
                             style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurface,
+                            color = onSurfaceLight,
                         )
                     }
                 },
@@ -216,7 +217,7 @@ private fun IssuesPanel(
                                                             modifier = Modifier.size(20.dp),
                                                         )
                                                         Text(
-                                                            text = it.label.value,
+                                                            text = composeNode.label.value,
                                                             style = MaterialTheme.typography.titleSmall,
                                                             color = MaterialTheme.colorScheme.onSurface,
                                                             modifier = Modifier.padding(start = 8.dp),

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/toolbar/LeftToolbar.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/toolbar/LeftToolbar.kt
@@ -21,7 +21,6 @@ import io.composeflow.custom.composeflowicons.NounAi
 import io.composeflow.keyboard.getCtrlKeyStr
 import io.composeflow.ui.Tooltip
 import io.composeflow.ui.modifier.hoverIconClickable
-import io.composeflow.ui.toolbar.TOOLBAR_TEST_TAG
 import org.jetbrains.compose.resources.stringResource
 
 @Composable


### PR DESCRIPTION
In the **desktop implementation**, the `DecoratedWindow` was removed and replaced with a **custom window implementation**, introducing `io.composeflow.ui.window.ComposeFlowWindow`, defined as an *expected declaration* (`expect fun`).  
This implementation uses `androidx.compose.ui.window.Window` along with helper functions from the JetBrains JBR API, such as:

- `JBR.isWindowDecorationsSupported()`
- `JBR.getWindowDecorations().setCustomTitleBar(window, customTitleBar)`
- `JBR.getWindowDecorations().createCustomTitleBar()`

As a result, the desktop toolbar implementation now depends on [JetBrains Runtime (JBR)](https://github.com/JetBrains/JetBrainsRuntime).

On the **WASM side**, the implementation is simpler and does not require any external libraries.