### PR TITLE
Replace Jewel SplitLayouts with custom implementations

### DIFF
--- a/core/ui/src/commonMain/kotlin/io/composeflow/ui/splitlayout/StatefulHorizontalSplitLayout.kt
+++ b/core/ui/src/commonMain/kotlin/io/composeflow/ui/splitlayout/StatefulHorizontalSplitLayout.kt
@@ -1,4 +1,4 @@
-package io.composeflow.ui.jewel
+package io.composeflow.ui.splitlayout
 
 import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
@@ -7,7 +7,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
@@ -27,10 +30,6 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.composeflow.ui.PointerIconResizeHorizontal
-import org.jetbrains.jewel.foundation.theme.JewelTheme
-import org.jetbrains.jewel.ui.Orientation
-import org.jetbrains.jewel.ui.component.Divider
-import org.jetbrains.jewel.ui.component.HorizontalSplitLayout
 import kotlin.math.roundToInt
 
 @Immutable
@@ -112,18 +111,12 @@ fun StatefulHorizontalSplitLayout(
     }
 }
 
-/**
- * Wrapper of [HorizontalSplitLayout] that accepts [onDividerPositionChanged] callback that emits
- * the changed divider position.
- * Also changed the behavior (or an issue?) that passing different initialDividerPosition value
- * will affect the actual divider's position in the next recomposition.
- */
 @Composable
 fun HorizontalSplitLayoutWrapper(
     first: @Composable (Modifier) -> Unit,
     second: @Composable (Modifier) -> Unit,
     modifier: Modifier = Modifier,
-    dividerColor: Color = JewelTheme.globalColors.borders.normal,
+    dividerColor: Color = MaterialTheme.colorScheme.outlineVariant,
     dividerThickness: Dp = 1.dp,
     dividerIndent: Dp = 0.dp,
     draggableWidth: Dp = 8.dp,
@@ -155,12 +148,14 @@ fun HorizontalSplitLayoutWrapper(
             val dividerInteractionSource = remember { MutableInteractionSource() }
             first(Modifier.layoutId("first"))
 
-            Divider(
-                orientation = Orientation.Vertical,
-                modifier = Modifier.fillMaxHeight().layoutId("divider"),
+            VerticalDivider(
+                modifier =
+                    Modifier
+                        .fillMaxHeight()
+                        .padding(start = dividerIndent)
+                        .layoutId("divider"),
                 color = dividerColor,
                 thickness = dividerThickness,
-                startIndent = dividerIndent,
             )
 
             second(Modifier.layoutId("second"))

--- a/core/ui/src/commonMain/kotlin/io/composeflow/ui/splitlayout/VerticalSplitLayout.kt
+++ b/core/ui/src/commonMain/kotlin/io/composeflow/ui/splitlayout/VerticalSplitLayout.kt
@@ -1,0 +1,111 @@
+package io.composeflow.ui.splitlayout
+
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.draggable
+import androidx.compose.foundation.gestures.rememberDraggableState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.BoxWithConstraintsScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.times
+import io.composeflow.ui.PointerIconResizeVertical
+
+@Composable
+fun VerticalSplitLayout(
+    modifier: Modifier = Modifier,
+    sliderThickness: Dp = 1.dp,
+    sliderColor: Color = MaterialTheme.colorScheme.outlineVariant,
+    initialSliderPosition: Dp = 100.dp,
+    minSliderRatio: Float = 0f,
+    maxSliderRatio: Float = 1f,
+    draggableWidth: Dp = 8.dp,
+    topContent: @Composable BoxWithConstraintsScope.() -> Unit,
+    bottomContent: @Composable BoxWithConstraintsScope.() -> Unit,
+) {
+    require(minSliderRatio in 0f..1f) { "minSliderRatio must be between 0f and 1f" }
+    require(maxSliderRatio in 0f..1f) { "maxSliderRatio must be between 0f and 1f" }
+    require(minSliderRatio < maxSliderRatio) { "minSliderRatio must be less than maxSliderRatio" }
+
+    BoxWithConstraints(
+        modifier = modifier,
+    ) {
+        val containerHeight = maxHeight
+        val density = LocalDensity.current
+
+        var sliderRatio by remember {
+            mutableStateOf(
+                initialSliderPosition.let { dp ->
+                    (dp / containerHeight).coerceIn(minSliderRatio, maxSliderRatio)
+                },
+            )
+        }
+        val sliderOffsetY by remember(sliderThickness, containerHeight, sliderRatio) {
+            derivedStateOf {
+                sliderRatio
+                    .times(containerHeight - sliderThickness)
+                    .coerceIn(0.dp, containerHeight - sliderThickness)
+            }
+        }
+
+        BoxWithConstraints(
+            modifier = Modifier.height(sliderOffsetY + sliderThickness / 2).fillMaxWidth(),
+            contentAlignment = Alignment.Center,
+        ) {
+            topContent(this)
+        }
+
+        BoxWithConstraints(
+            modifier = Modifier.fillMaxSize().padding(top = sliderOffsetY + sliderThickness / 2),
+            contentAlignment = Alignment.Center,
+        ) {
+            bottomContent(this)
+        }
+
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(draggableWidth)
+                    .offset(y = sliderOffsetY)
+                    .draggable(
+                        orientation = Orientation.Vertical,
+                        state =
+                            rememberDraggableState { delta ->
+                                val deltaDp = with(density) { delta.toDp() }
+                                val newOffset =
+                                    (sliderOffsetY + deltaDp).coerceIn(
+                                        0.dp,
+                                        containerHeight - sliderThickness,
+                                    )
+                                sliderRatio =
+                                    (newOffset / (containerHeight - sliderThickness))
+                                        .coerceIn(minSliderRatio, maxSliderRatio)
+                            },
+                    ).pointerHoverIcon(PointerIconResizeVertical),
+        ) {
+            HorizontalDivider(
+                thickness = sliderThickness,
+                color = sliderColor,
+            )
+        }
+    }
+}

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/uibuilder/UiBuilderScreen.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/uibuilder/UiBuilderScreen.kt
@@ -155,9 +155,6 @@ import io.composeflow.ui.handleMessages
 import io.composeflow.ui.icon.ComposeFlowIcon
 import io.composeflow.ui.inspector.InspectorTab
 import io.composeflow.ui.inspector.modifier.AddModifierDialog
-import io.composeflow.ui.jewel.SplitLayoutState
-import io.composeflow.ui.jewel.StatefulHorizontalSplitLayout
-import io.composeflow.ui.jewel.rememberSplitLayoutState
 import io.composeflow.ui.modifier.backgroundContainerNeutral
 import io.composeflow.ui.modifier.hoverIconClickable
 import io.composeflow.ui.modifierForCanvas
@@ -166,6 +163,10 @@ import io.composeflow.ui.palette.PaletteIcon
 import io.composeflow.ui.palette.PaletteTab
 import io.composeflow.ui.popup.SingleTextInputDialog
 import io.composeflow.ui.screenbuilder.ScreenBuilderTab
+import io.composeflow.ui.splitlayout.SplitLayoutState
+import io.composeflow.ui.splitlayout.StatefulHorizontalSplitLayout
+import io.composeflow.ui.splitlayout.VerticalSplitLayout
+import io.composeflow.ui.splitlayout.rememberSplitLayoutState
 import io.composeflow.ui.tab.ComposeFlowTab
 import io.composeflow.ui.uibuilder.onboarding.OnboardingManager
 import io.composeflow.ui.uibuilder.onboarding.OnboardingOverlay
@@ -179,7 +180,6 @@ import io.composeflow.zoom_out
 import kotlinx.coroutines.CoroutineScope
 import moe.tlaster.precompose.viewmodel.viewModel
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.jewel.ui.component.VerticalSplitLayout
 import kotlin.math.roundToInt
 
 @Composable
@@ -554,11 +554,11 @@ private fun LeftPane(
     ) {
         val maxHeight = maxHeight.value.dp
         VerticalSplitLayout(
-            initialDividerPosition = maxHeight / 2,
-            minRatio = 0.25f,
-            maxRatio = 0.75f,
-            first = { firstModifier ->
-                Column(modifier = firstModifier) {
+            initialSliderPosition = maxHeight / 2,
+            minSliderRatio = 0.25f,
+            maxSliderRatio = 0.75f,
+            topContent = {
+                Column {
                     var selectedTabIndex by remember { mutableStateOf(0) }
                     TabRow(
                         selectedTabIndex = selectedTabIndex,
@@ -661,7 +661,7 @@ private fun LeftPane(
                     }
                 }
             },
-            second = { secondModifier ->
+            bottomContent = {
                 ComposeNodeTree(
                     project = project,
                     copiedNodes = copiedNodes,
@@ -675,10 +675,11 @@ private fun LeftPane(
                     onShowActionTab = onShowActionTab,
                     onShowSnackbar = onShowSnackbar,
                     modifier =
-                        secondModifier.onboardingTarget(
-                            TargetArea.ProjectStructure,
-                            onboardingManager,
-                        ),
+                        Modifier
+                            .onboardingTarget(
+                                TargetArea.ProjectStructure,
+                                onboardingManager,
+                            ),
                 )
             },
         )


### PR DESCRIPTION
Replaces the **VerticalSplitLayout** from Jewel with a custom version located at `io.composeflow.ui.splitlayout.VerticalSplitLayout`.  
For the **HorizontalSplitLayout**, a custom version already existed in `io.composeflow.ui.jewel.StatefulHorizontalSplitLayout`. However, it depended on some Jewel styling. This PR removes all Jewel styling dependencies and moves it to `io.composeflow.ui.splitlayout.StatefulHorizontalSplitLayout`.

Closes #137
