### PR TITLE
Fix TextField focus loss on Space key in AssignableEditableTextPropertyEditor

### DIFF
--- a/core/model/src/commonMain/kotlin/io/composeflow/ui/propertyeditor/AssignableEditableTextPropertyEditor.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/ui/propertyeditor/AssignableEditableTextPropertyEditor.kt
@@ -13,6 +13,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.unit.dp
 import io.composeflow.Res
 import io.composeflow.editor.validator.ValidateResult
@@ -82,7 +87,12 @@ fun AssignableEditableTextPropertyEditor(
     val errorText = initialProperty?.getErrorMessage(project, acceptableType)
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier,
+        modifier =
+            modifier
+                .onPreviewKeyEvent { event ->
+                    // intercepts the spacebar click so the textField doesn't lose focus
+                    event.key == Key.Spacebar && event.type == KeyEventType.KeyDown
+                },
     ) {
         EditableTextProperty(
             enabled = textFieldEnabled,


### PR DESCRIPTION
Fixed #91 

On desktop, some components like TabRow and BottomAppBar capture certain key events for accessibility, which caused the TextField to lose focus when typing a space. 

This change intercepts the Space key press inside AssignableEditableTextPropertyEditor to prevent focus loss.

