### PR TITLE
 Implement FallbackEnumSerializer to fix UI builder drag-and-drop freeze

### DIFF
--- a/core/model/src/commonMain/kotlin/io/composeflow/materialicons/Filled.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/materialicons/Filled.kt
@@ -56,7 +56,10 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
-object FilledSerializer : FallbackEnumSerializer<Filled>(Filled::class)
+object FilledSerializer : FallbackEnumSerializer<Filled>(
+    Filled::class,
+    Filled.entries.toTypedArray(),
+)
 
 /**
  * Enum of Filled icons from material-icons-core

--- a/core/model/src/commonMain/kotlin/io/composeflow/materialicons/Outlined.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/materialicons/Outlined.kt
@@ -2082,7 +2082,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
-object OutlinedSerializer : FallbackEnumSerializer<Outlined>(Outlined::class)
+object OutlinedSerializer : FallbackEnumSerializer<Outlined>(Outlined::class, Outlined.entries.toTypedArray())
 
 /**
  * Enum of Outlined icons from material-icons-core and material-icons-extended libraries.

--- a/core/model/src/commonMain/kotlin/io/composeflow/materialicons/Rounded.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/materialicons/Rounded.kt
@@ -56,7 +56,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
-object RoundedSerializer : FallbackEnumSerializer<Rounded>(Rounded::class)
+object RoundedSerializer : FallbackEnumSerializer<Rounded>(Rounded::class, Rounded.entries.toTypedArray())
 
 /**
  * Enum of rounded icons from material-icons-core

--- a/core/model/src/commonMain/kotlin/io/composeflow/materialicons/Sharp.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/materialicons/Sharp.kt
@@ -56,7 +56,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
-object SharpSerializer : FallbackEnumSerializer<Sharp>(Sharp::class)
+object SharpSerializer : FallbackEnumSerializer<Sharp>(Sharp::class, Sharp.entries.toTypedArray())
 
 /**
  * Enum of Sharp icons from material-icons-core and material-icons-extended libraries

--- a/core/model/src/commonMain/kotlin/io/composeflow/materialicons/TwoTone.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/materialicons/TwoTone.kt
@@ -56,7 +56,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
-object TwoToneSerializer : FallbackEnumSerializer<TwoTone>(TwoTone::class)
+object TwoToneSerializer : FallbackEnumSerializer<TwoTone>(TwoTone::class, TwoTone.entries.toTypedArray())
 
 /**
  * Enum of TwoTone icons from material-icons-core

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/enumwrapper/EnumWrapper.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/enumwrapper/EnumWrapper.kt
@@ -60,7 +60,7 @@ enum class TextDecorationWrapper(
         )
 
     object TextDecorationWrapperSerializer :
-        FallbackEnumSerializer<TextDecorationWrapper>(TextDecorationWrapper::class)
+        FallbackEnumSerializer<TextDecorationWrapper>(TextDecorationWrapper::class, TextDecorationWrapper.entries.toTypedArray())
 }
 
 @SerialName("TextStyleWrapper")
@@ -260,7 +260,7 @@ enum class TextStyleWrapper(
     override fun asCodeBlock(): CodeBlockWrapper = CodeBlockWrapper.of("%M.typography.$styleName", MemberHolder.Material3.MaterialTheme)
 
     object TextStyleWrapperSerializer :
-        FallbackEnumSerializer<TextStyleWrapper>(TextStyleWrapper::class)
+        FallbackEnumSerializer<TextStyleWrapper>(TextStyleWrapper::class, TextStyleWrapper.entries.toTypedArray())
 }
 
 @SerialName("FontStyleWrapper")
@@ -286,7 +286,7 @@ enum class FontStyleWrapper(
         )
 
     object FontStyleWrapperSerializer :
-        FallbackEnumSerializer<FontStyleWrapper>(FontStyleWrapper::class)
+        FallbackEnumSerializer<FontStyleWrapper>(FontStyleWrapper::class, FontStyleWrapper.entries.toTypedArray())
 }
 
 @SerialName("TextAlignWrapper")
@@ -316,7 +316,7 @@ enum class TextAlignWrapper(
         )
 
     object TextAlignWrapperSerializer :
-        FallbackEnumSerializer<TextAlignWrapper>(TextAlignWrapper::class)
+        FallbackEnumSerializer<TextAlignWrapper>(TextAlignWrapper::class, TextAlignWrapper.entries.toTypedArray())
 }
 
 @SerialName("TextOverflowWrapper")
@@ -343,7 +343,7 @@ enum class TextOverflowWrapper(
         )
 
     object TextOverflowWrapperSerializer :
-        FallbackEnumSerializer<TextOverflowWrapper>(TextOverflowWrapper::class)
+        FallbackEnumSerializer<TextOverflowWrapper>(TextOverflowWrapper::class, TextOverflowWrapper.entries.toTypedArray())
 }
 
 @SerialName("ContentScaleWrapper")
@@ -374,7 +374,7 @@ enum class ContentScaleWrapper(
         )
 
     object ContentScaleWrapperSerializer :
-        FallbackEnumSerializer<ContentScaleWrapper>(ContentScaleWrapper::class)
+        FallbackEnumSerializer<ContentScaleWrapper>(ContentScaleWrapper::class, ContentScaleWrapper.entries.toTypedArray())
 }
 
 @SerialName("TextFieldColorsWrapper")
@@ -404,7 +404,7 @@ enum class TextFieldColorsWrapper : EnumWrapper {
         }
 
     object TextFieldColorsWrapperSerializer :
-        FallbackEnumSerializer<TextFieldColorsWrapper>(TextFieldColorsWrapper::class)
+        FallbackEnumSerializer<TextFieldColorsWrapper>(TextFieldColorsWrapper::class, TextFieldColorsWrapper.entries.toTypedArray())
 }
 
 @SerialName("NodeVisibility")
@@ -439,5 +439,5 @@ enum class NodeVisibility :
     override fun asCodeBlock(): CodeBlockWrapper = CodeBlockWrapper.of("")
 
     object NodeVisibilitySerializer :
-        FallbackEnumSerializer<NodeVisibility>(NodeVisibility::class)
+        FallbackEnumSerializer<NodeVisibility>(NodeVisibility::class, NodeVisibility.entries.toTypedArray())
 }

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/AbstractIconTrait.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/AbstractIconTrait.kt
@@ -277,7 +277,7 @@ abstract class AbstractIconTrait(
 }
 
 object IconAssetTypeSerializer :
-    FallbackEnumSerializer<IconAssetType>(IconAssetType::class)
+    FallbackEnumSerializer<IconAssetType>(IconAssetType::class, IconAssetType.entries.toTypedArray())
 
 @Serializable(IconAssetTypeSerializer::class)
 enum class IconAssetType {

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/ButtonTrait.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/ButtonTrait.kt
@@ -353,5 +353,8 @@ enum class ButtonType {
 
     abstract fun toMemberName(): MemberNameWrapper
 
-    object Serializer : FallbackEnumSerializer<ButtonType>(ButtonType::class)
+    object Serializer : FallbackEnumSerializer<ButtonType>(
+        ButtonType::class,
+        entries.toTypedArray(),
+    )
 }

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/CardTrait.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/CardTrait.kt
@@ -222,7 +222,7 @@ data class CardTrait(
     }
 }
 
-object CardTypeSerializer : FallbackEnumSerializer<CardType>(CardType::class)
+object CardTypeSerializer : FallbackEnumSerializer<CardType>(CardType::class, CardType.entries.toTypedArray())
 
 @Serializable(CardTypeSerializer::class)
 enum class CardType {

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/FabTrait.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/FabTrait.kt
@@ -328,6 +328,7 @@ data class FabTrait(
 
 object FabElevationWrapperSerializer : FallbackEnumSerializer<FabElevationWrapper>(
     FabElevationWrapper::class,
+    FabElevationWrapper.entries.toTypedArray(),
 )
 
 @Serializable(FabElevationWrapperSerializer::class)
@@ -338,6 +339,7 @@ enum class FabElevationWrapper {
 
 object FabPositionWrapperSerializer : FallbackEnumSerializer<FabPositionWrapper>(
     FabPositionWrapper::class,
+    FabPositionWrapper.entries.toTypedArray(),
 )
 
 @Serializable(FabPositionWrapperSerializer::class)
@@ -346,7 +348,7 @@ enum class FabPositionWrapper {
     Center,
 }
 
-object FabTypeSerializer : FallbackEnumSerializer<FabType>(FabType::class)
+object FabTypeSerializer : FallbackEnumSerializer<FabType>(FabType::class, FabType.entries.toTypedArray())
 
 @Serializable(FabTypeSerializer::class)
 enum class FabType {

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/ImageTrait.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/ImageTrait.kt
@@ -345,7 +345,7 @@ data class ImageTrait(
 const val DEFAULT_URL = "https://picsum.photos/480"
 
 object ImageAssetTypeSerializer :
-    FallbackEnumSerializer<ImageAssetType>(ImageAssetType::class)
+    FallbackEnumSerializer<ImageAssetType>(ImageAssetType::class, ImageAssetType.entries.toTypedArray())
 
 @Serializable(ImageAssetTypeSerializer::class)
 enum class ImageAssetType {

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/NavigationDrawerTrait.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/NavigationDrawerTrait.kt
@@ -130,7 +130,7 @@ data class NavigationDrawerTrait(
 }
 
 object NavigationDrawerTypeSerializer :
-    FallbackEnumSerializer<NavigationDrawerType>(NavigationDrawerType::class)
+    FallbackEnumSerializer<NavigationDrawerType>(NavigationDrawerType::class, NavigationDrawerType.entries.toTypedArray())
 
 @Serializable(NavigationDrawerTypeSerializer::class)
 enum class NavigationDrawerType {

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/TextFieldTrait.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/TextFieldTrait.kt
@@ -636,6 +636,7 @@ data class TextFieldTrait(
 
 object TextFieldTypeSerializer : FallbackEnumSerializer<TextFieldType>(
     TextFieldType::class,
+    TextFieldType.entries.toTypedArray(),
 )
 
 @Serializable(TextFieldTypeSerializer::class)

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/TopAppBarTrait.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/TopAppBarTrait.kt
@@ -440,6 +440,7 @@ data class TopAppBarTrait(
 
 object TopAppBarTypeWrapperSerializer : FallbackEnumSerializer<TopAppBarTypeWrapper>(
     TopAppBarTypeWrapper::class,
+    TopAppBarTypeWrapper.entries.toTypedArray(),
 )
 
 @Serializable(TopAppBarTypeWrapperSerializer::class)
@@ -452,6 +453,7 @@ enum class TopAppBarTypeWrapper {
 
 object ScrollBehaviorWrapperSerializer : FallbackEnumSerializer<ScrollBehaviorWrapper>(
     ScrollBehaviorWrapper::class,
+    ScrollBehaviorWrapper.entries.toTypedArray(),
 )
 
 @Serializable(ScrollBehaviorWrapperSerializer::class)

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/AlignmentHorizontalWrapper.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/AlignmentHorizontalWrapper.kt
@@ -5,7 +5,10 @@ import io.composeflow.serializer.FallbackEnumSerializer
 import kotlinx.serialization.Serializable
 
 object AlignmentHorizontalWrapperSerializer :
-    FallbackEnumSerializer<AlignmentHorizontalWrapper>(AlignmentHorizontalWrapper::class)
+    FallbackEnumSerializer<AlignmentHorizontalWrapper>(
+        AlignmentHorizontalWrapper::class,
+        AlignmentHorizontalWrapper.entries.toTypedArray(),
+    )
 
 @Serializable(AlignmentHorizontalWrapperSerializer::class)
 enum class AlignmentHorizontalWrapper(

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/AlignmentVerticalWrapper.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/AlignmentVerticalWrapper.kt
@@ -5,7 +5,10 @@ import io.composeflow.serializer.FallbackEnumSerializer
 import kotlinx.serialization.Serializable
 
 object AlignmentVerticalWrapperSerializer :
-    FallbackEnumSerializer<AlignmentVerticalWrapper>(AlignmentVerticalWrapper::class)
+    FallbackEnumSerializer<AlignmentVerticalWrapper>(
+        AlignmentVerticalWrapper::class,
+        AlignmentVerticalWrapper.entries.toTypedArray(),
+    )
 
 @Serializable(AlignmentVerticalWrapperSerializer::class)
 enum class AlignmentVerticalWrapper(

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/AlignmentWrapper.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/AlignmentWrapper.kt
@@ -5,7 +5,7 @@ import io.composeflow.serializer.FallbackEnumSerializer
 import kotlinx.serialization.Serializable
 
 object AlignmentWrapperSerializer :
-    FallbackEnumSerializer<AlignmentWrapper>(AlignmentWrapper::class)
+    FallbackEnumSerializer<AlignmentWrapper>(AlignmentWrapper::class, AlignmentWrapper.entries.toTypedArray())
 
 @Serializable(AlignmentWrapperSerializer::class)
 enum class AlignmentWrapper(

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/ArrangementHorizontalWrapper.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/ArrangementHorizontalWrapper.kt
@@ -5,7 +5,10 @@ import io.composeflow.serializer.FallbackEnumSerializer
 import kotlinx.serialization.Serializable
 
 object ArrangementHorizontalWrapperSerializer :
-    FallbackEnumSerializer<ArrangementHorizontalWrapper>(ArrangementHorizontalWrapper::class)
+    FallbackEnumSerializer<ArrangementHorizontalWrapper>(
+        ArrangementHorizontalWrapper::class,
+        ArrangementHorizontalWrapper.entries.toTypedArray(),
+    )
 
 @Serializable(ArrangementHorizontalWrapperSerializer::class)
 enum class ArrangementHorizontalWrapper(

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/ArrangementVerticalWrapper.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/ArrangementVerticalWrapper.kt
@@ -5,7 +5,10 @@ import io.composeflow.serializer.FallbackEnumSerializer
 import kotlinx.serialization.Serializable
 
 object ArrangementVerticalWrapperSerializer :
-    FallbackEnumSerializer<ArrangementVerticalWrapper>(ArrangementVerticalWrapper::class)
+    FallbackEnumSerializer<ArrangementVerticalWrapper>(
+        ArrangementVerticalWrapper::class,
+        ArrangementVerticalWrapper.entries.toTypedArray(),
+    )
 
 @Serializable(ArrangementVerticalWrapperSerializer::class)
 enum class ArrangementVerticalWrapper(

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/BrushWrapper.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/BrushWrapper.kt
@@ -307,7 +307,10 @@ data class BrushWrapper(
     }
 }
 
-object BrushTypeSerializer : FallbackEnumSerializer<BrushType>(BrushType::class)
+object BrushTypeSerializer : FallbackEnumSerializer<BrushType>(
+    BrushType::class,
+    BrushType.entries.toTypedArray(),
+)
 
 @Serializable(BrushTypeSerializer::class)
 enum class BrushType(

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/ColorWrapper.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/ColorWrapper.kt
@@ -48,7 +48,10 @@ data class ColorWrapper(
 }
 
 object Material3ColorWrapperSerializer :
-    FallbackEnumSerializer<Material3ColorWrapper>(Material3ColorWrapper::class)
+    FallbackEnumSerializer<Material3ColorWrapper>(
+        Material3ColorWrapper::class,
+        Material3ColorWrapper.entries.toTypedArray(),
+    )
 
 /**
  * Wrapper class for [Color] to distinguish the same color by semantics.

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/SnapPositionWrapper.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/SnapPositionWrapper.kt
@@ -6,7 +6,10 @@ import io.composeflow.serializer.FallbackEnumSerializer
 import kotlinx.serialization.Serializable
 
 object SnapPositionWrapperSerializer :
-    FallbackEnumSerializer<SnapPositionWrapper>(SnapPositionWrapper::class)
+    FallbackEnumSerializer<SnapPositionWrapper>(
+        SnapPositionWrapper::class,
+        SnapPositionWrapper.entries.toTypedArray(),
+    )
 
 @Serializable(SnapPositionWrapperSerializer::class)
 enum class SnapPositionWrapper {

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/TileModeWrapper.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/TileModeWrapper.kt
@@ -5,7 +5,10 @@ import io.composeflow.serializer.FallbackEnumSerializer
 import kotlinx.serialization.Serializable
 
 object TileModeWrapperSerializer :
-    FallbackEnumSerializer<TileModeWrapper>(TileModeWrapper::class)
+    FallbackEnumSerializer<TileModeWrapper>(
+        TileModeWrapper::class,
+        TileModeWrapper.entries.toTypedArray(),
+    )
 
 @Serializable(TileModeWrapperSerializer::class)
 enum class TileModeWrapper {

--- a/core/serializer/src/commonMain/kotlin/io/composeflow/serializer/FallbackEnumSerializer.kt
+++ b/core/serializer/src/commonMain/kotlin/io/composeflow/serializer/FallbackEnumSerializer.kt
@@ -8,6 +8,7 @@ import kotlin.reflect.KClass
 
 expect class FallbackEnumSerializerInternal<T : Enum<T>>(
     enumClass: KClass<T>,
+    values: Array<T>,
 ) : KSerializer<T> {
     override val descriptor: SerialDescriptor
 
@@ -25,8 +26,13 @@ expect class FallbackEnumSerializerInternal<T : Enum<T>>(
  */
 open class FallbackEnumSerializer<T : Enum<T>>(
     enumClass: KClass<T>,
+    values: Array<T>,
 ) : KSerializer<T> {
-    private val delegate = FallbackEnumSerializerInternal(enumClass).withLocationAwareExceptions()
+    private val delegate =
+        FallbackEnumSerializerInternal(
+            enumClass,
+            values,
+        ).withLocationAwareExceptions()
 
     override val descriptor: SerialDescriptor = delegate.descriptor
 

--- a/core/serializer/src/jvmMain/kotlin/io/composeflow/serializer/FallbackEnumSerializer.jvm.kt
+++ b/core/serializer/src/jvmMain/kotlin/io/composeflow/serializer/FallbackEnumSerializer.jvm.kt
@@ -17,6 +17,7 @@ import kotlin.reflect.KClass
  */
 actual class FallbackEnumSerializerInternal<T : Enum<T>> actual constructor(
     enumClass: KClass<T>,
+    values: Array<T>,
 ) : KSerializer<T> {
     private val values = enumClass.java.enumConstants ?: arrayOf()
     private val fallback =


### PR DESCRIPTION
Fixed #154

Dropping a Composable onto a device in the UI builder was freezing the web application because `FallbackEnumSerializerInternal` was not implemented for WASM.

On WASM, there is no reflection, so we cannot use `enumClass.java.enumConstants` to get the enum values. A workaround is to **pass the `values` array explicitly** when defining the serializer:

```kotlin
object CardTypeSerializer : FallbackEnumSerializer<CardType>(
    CardType::class,
    CardType.entries.toTypedArray()
)

```

This explicit approach can be considered a temporary but effective solution for WASM. See the demonstration video below:

https://github.com/user-attachments/assets/461f21e1-7ae0-498d-85ca-55f10fa10e6c

