### PR TITLE
Convert window size from px to dp correctly with Density

### DIFF
--- a/core/platform/src/jvmMain/kotlin/io/composeflow/platform/WindowSize.kt
+++ b/core/platform/src/jvmMain/kotlin/io/composeflow/platform/WindowSize.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.DpSize
-import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable


### PR DESCRIPTION
Close #164.

rememberWindowSize() returned unexpectedly enlarged window size by just using the px value as dp. Fixed it by converting px values with Density.

I confirmed all other places use `Int.dp` correctly.

After fix:
<img width="6016" height="3334" alt="CleanShot 2025-09-11 at 03 18 04@2x" src="https://github.com/user-attachments/assets/d738a6bc-cfe4-42ea-a406-c530859d0b38" />
