### PR TITLE
Add right-click support to TreeView

### DIFF
--- a/core/ui/src/commonMain/kotlin/io/composeflow/ui/treeview/TreeView.kt
+++ b/core/ui/src/commonMain/kotlin/io/composeflow/ui/treeview/TreeView.kt
@@ -76,6 +76,7 @@ fun <T> TreeView(
     onClick: ((node: Node<T>, ctrl: Boolean, shift: Boolean) -> Unit)? = null,
     onDoubleClick: OnNodeClick<T> = tree::toggleExpansion,
     onLongClick: OnNodeClick<T> = tree::toggleSelection,
+    onRightClick: OnNodeClick<T> = tree::onNodeClick,
     onHover: OnNodeHover<T> = ::onNodeHover,
     style: TreeViewStyle<T> =
         TreeViewStyle(
@@ -103,6 +104,7 @@ fun <T> TreeView(
                 style = style,
                 onClick = onClick,
                 onLongClick = onLongClick,
+                onRightClick = onRightClick,
                 onDoubleClick = onDoubleClick,
                 onHover = onHover,
             )

--- a/core/ui/src/commonMain/kotlin/io/composeflow/ui/treeview/TreeViewScope.kt
+++ b/core/ui/src/commonMain/kotlin/io/composeflow/ui/treeview/TreeViewScope.kt
@@ -22,6 +22,7 @@ data class TreeViewScope<T> internal constructor(
     val style: TreeViewStyle<T>,
     val onClick: ((node: Node<T>, ctrl: Boolean, shift: Boolean) -> Unit)? = null,
     val onLongClick: OnNodeClick<T>,
+    val onRightClick: OnNodeClick<T>,
     val onDoubleClick: OnNodeClick<T>,
     val onHover: OnNodeHover<T>,
 )

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/nodetree/ComoseNodeTree.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/nodetree/ComoseNodeTree.kt
@@ -174,16 +174,19 @@ fun ComposeNodeTree(
             listState = lazyListState,
             onClick = { treeNode, isCtrlOrMetaPressed, isShitPressed ->
                 project.screenHolder.clearIsFocused()
-
                 val nodes =
                     tree.handleMultipleSelection(treeNode, isCtrlOrMetaPressed, isShitPressed)
                 nodes.forEach {
                     it.content.setFocus()
                 }
             },
+            onRightClick = { node ->
+                project.screenHolder.clearIsFocused()
+                node.content.setFocus()
+                contextMenuExpanded = true
+            },
             onHover = { node, isHovered ->
                 node.content.isHovered.value = isHovered
-
                 tree.setHovered(node, isHovered)
             },
         )


### PR DESCRIPTION
Adds `onRightClick` callback to `TreeViewScope` and `TreeView`.  
In `ComposeNodeTree`, `onRightClick` focuses the node and opens a context menu.

Fixes #167