### PR TITLE
Fix icon tint in NavigationRail

### DIFF
--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/navigationrail/LeftNavigationRail.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/navigationrail/LeftNavigationRail.kt
@@ -62,7 +62,6 @@ fun LeftNavigationRail(navigator: Navigator) {
                 .fillMaxHeight(),
     ) {
         TopLevelDestination.entries.forEachIndexed { index, item ->
-            @Suppress("KotlinConstantConditions")
             if (BuildConfig.isRelease) {
                 if (item == TopLevelDestination.StringEditor) {
                     return@forEachIndexed
@@ -104,6 +103,7 @@ fun LeftNavigationRail(navigator: Navigator) {
                             Icon(
                                 imageVector = icon,
                                 contentDescription = "icon",
+                                tint = Color.Unspecified,
                                 modifier = Modifier.size(20.dp),
                             )
                         }


### PR DESCRIPTION
This PR fixes the icon tint issue in the NavigationRail by setting the icon color to 
`Color.Unspecified`. This ensures icons keep their original colors instead of inheriting 
`LocalContentColor.current`.