### PR TITLE
Fix the drop index when a Composable is dropped

### DIFF
--- a/core/model/src/commonMain/kotlin/io/composeflow/ui/Modifiers.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/ui/Modifiers.kt
@@ -1034,19 +1034,19 @@ fun Modifier.draggableFromPalette(
                 )
             },
             onDragEnd = {
-                paletteDraggable.defaultComposeNode(project)?.let { composeNode ->
-                    composeNode.updateComposeNodeReferencesForTrait()
+                coroutineScope.launch {
+                    paletteDraggable.defaultComposeNode(project)?.let { composeNode ->
+                        composeNode.updateComposeNodeReferencesForTrait()
 
-                    coroutineScope.launch {
                         paletteNodeCallbacks.onComposableDroppedToTarget(
                             localToRoot + (pointerPosition - zoomableContainerStateHolder.offset) / zoomableContainerStateHolder.scale,
                             composeNode,
                         )
                     }
-                }
 
-                paletteNodeCallbacks.onDraggedNodeUpdated(null)
-                paletteNodeCallbacks.onDragEnd()
+                    paletteNodeCallbacks.onDraggedNodeUpdated(null)
+                    paletteNodeCallbacks.onDragEnd()
+                }
             },
         )
     }.onGloballyPositioned {


### PR DESCRIPTION
Fixes https://github.com/ComposeFlow/ComposeFlow/issues/168 

This fixes the drop index when a Composable is dropped to the device in the UI builder.
As part of the WASM integration, part of onDragEnd method was changed to start from a coroutine scope, but it introduced an issue where the drop position is calculated before the actual drop operation.

The fixes ensures proper order of the drop position calculation.
