### PR TITLE
Add a function to update compose node's trait in UiBuilderOperator

### DIFF
--- a/core/ai/src/commonMain/kotlin/io/composeflow/ai/openrouter/tools/OpenRouterToolResult.kt
+++ b/core/ai/src/commonMain/kotlin/io/composeflow/ai/openrouter/tools/OpenRouterToolResult.kt
@@ -66,6 +66,13 @@ sealed interface OpenRouterToolResult {
     ) : OpenRouterToolResult
 
     @Serializable
+    data class UpdateTraitArgs(
+        override val tool_name: String = "update_trait",
+        override val tool_call_id: String,
+        override val tool_args: ToolArgs.UpdateTraitArgs,
+    ) : OpenRouterToolResult
+
+    @Serializable
     data class MoveComposeNodeToContainerArgs(
         override val tool_name: String = "move_compose_node_to_container",
         override val tool_call_id: String,

--- a/core/ai/src/commonMain/kotlin/io/composeflow/ai/openrouter/tools/OpenRouterToolResultSerializer.kt
+++ b/core/ai/src/commonMain/kotlin/io/composeflow/ai/openrouter/tools/OpenRouterToolResultSerializer.kt
@@ -108,6 +108,15 @@ object OpenRouterToolResultSerializer : KSerializer<OpenRouterToolResult> {
                             ),
                         )
 
+                    is OpenRouterToolResult.UpdateTraitArgs ->
+                        put(
+                            "tool_args",
+                            json.encodeToJsonElement(
+                                ToolArgs.UpdateTraitArgs.serializer(),
+                                value.tool_args,
+                            ),
+                        )
+
                     is OpenRouterToolResult.MoveComposeNodeToContainerArgs ->
                         put(
                             "tool_args",
@@ -430,6 +439,19 @@ object OpenRouterToolResultSerializer : KSerializer<OpenRouterToolResult> {
                         processedToolArgsElement,
                     )
                 OpenRouterToolResult.SwapModifiersArgs(
+                    tool_name = toolName,
+                    tool_call_id = toolCallId,
+                    tool_args = toolArgs,
+                )
+            }
+
+            "update_trait" -> {
+                val toolArgs =
+                    json.decodeFromJsonElement(
+                        ToolArgs.UpdateTraitArgs.serializer(),
+                        processedToolArgsElement,
+                    )
+                OpenRouterToolResult.UpdateTraitArgs(
                     tool_name = toolName,
                     tool_call_id = toolCallId,
                     tool_args = toolArgs,

--- a/core/ai/src/commonMain/kotlin/io/composeflow/ai/openrouter/tools/ToolArgs.kt
+++ b/core/ai/src/commonMain/kotlin/io/composeflow/ai/openrouter/tools/ToolArgs.kt
@@ -72,6 +72,13 @@ sealed class ToolArgs {
     ) : ToolArgs()
 
     @Serializable
+    @SerialName("update_trait")
+    data class UpdateTraitArgs(
+        val composeNodeId: String,
+        val traitYaml: String,
+    ) : ToolArgs()
+
+    @Serializable
     @SerialName("move_compose_node_to_container")
     data class MoveComposeNodeToContainerArgs(
         val composeNodeId: String,

--- a/core/model/src/commonMain/kotlin/io/composeflow/ai/LlmRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/ai/LlmRepository.kt
@@ -430,6 +430,11 @@ class LlmRepository(
                 estimatedSize += 40 // fromIndex + toIndex
             }
 
+            is ToolArgs.UpdateTraitArgs -> {
+                estimatedSize += toolArg.composeNodeId.length
+                estimatedSize += toolArg.traitYaml.length
+            }
+
             is ToolArgs.MoveComposeNodeToContainerArgs -> {
                 estimatedSize += toolArg.composeNodeId.length
                 estimatedSize += toolArg.containerNodeId.length

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ai/ToolDispatcher.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ai/ToolDispatcher.kt
@@ -93,6 +93,14 @@ class ToolDispatcher(
                 )
             }
 
+            is ToolArgs.UpdateTraitArgs -> {
+                uiBuilderOperator.onUpdateTrait(
+                    project,
+                    toolArgs.composeNodeId,
+                    toolArgs.traitYaml,
+                )
+            }
+
             is ToolArgs.UpdateModifierArgs -> {
                 uiBuilderOperator.onUpdateModifier(
                     project,


### PR DESCRIPTION
Close #174.

I added a function that only updates the Trait. I could have added a function that updates the entire ComposeNode, but that would complicate validation, and it'd be inconsistent with the other functions in UiBuilderOperator.