### PR TITLE
Fix the issue when dropping Tabs from palette

### DIFF
--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/TabsTrait.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/TabsTrait.kt
@@ -37,10 +37,7 @@ import org.jetbrains.compose.resources.StringResource
 @Serializable
 @SerialName("TabsTrait")
 data object TabsTrait : ComposeTrait {
-    override fun defaultConstraints(): Set<Constraint> =
-        defaultConstraints().toMutableSet().apply {
-            add(Constraint.NestedTabs)
-        }
+    override fun defaultConstraints(): Set<Constraint> = setOf(Constraint.NestedTabs)
 
     override fun defaultComposeNode(project: Project): ComposeNode {
         val tabContainer =


### PR DESCRIPTION
Fixes #179

This fixes the crash that occurs when dropping Tabs from the palette in the UI builder.

The issue was caused by an infinite recursive call in TabsTrait.defaultConstraints(), which led to a java.lang.StackOverflowError. 

defaultConstraints() returns a simple setOf(Constraint.NestedTabs) instead of calling itself recursively.
