### PR TITLE
Wire LLM tools of string resource editor and allow LLM to interact with string resources

### DIFF
--- a/core/ai/src/commonMain/kotlin/io/composeflow/ai/openrouter/tools/OpenRouterToolResult.kt
+++ b/core/ai/src/commonMain/kotlin/io/composeflow/ai/openrouter/tools/OpenRouterToolResult.kt
@@ -225,4 +225,60 @@ sealed interface OpenRouterToolResult {
         override val tool_call_id: String,
         override val tool_args: ToolArgs.GetScreenDetailsArgs,
     ) : OpenRouterToolResult
+
+    @Serializable
+    data class AddStringResourcesArgs(
+        override val tool_name: String = "add_string_resources",
+        override val tool_call_id: String,
+        override val tool_args: ToolArgs.AddStringResourcesArgs,
+    ) : OpenRouterToolResult
+
+    @Serializable
+    data class DeleteStringResourcesArgs(
+        override val tool_name: String = "delete_string_resources",
+        override val tool_call_id: String,
+        override val tool_args: ToolArgs.DeleteStringResourcesArgs,
+    ) : OpenRouterToolResult
+
+    @Serializable
+    data class UpdateStringResourcesArgs(
+        override val tool_name: String = "update_string_resources",
+        override val tool_call_id: String,
+        override val tool_args: ToolArgs.UpdateStringResourcesArgs,
+    ) : OpenRouterToolResult
+
+    @Serializable
+    data class UpdateSupportedLocalesArgs(
+        override val tool_name: String = "update_supported_locales",
+        override val tool_call_id: String,
+        override val tool_args: ToolArgs.UpdateSupportedLocalesArgs,
+    ) : OpenRouterToolResult
+
+    @Serializable
+    data class SetDefaultLocaleArgs(
+        override val tool_name: String = "set_default_locale",
+        override val tool_call_id: String,
+        override val tool_args: ToolArgs.SetDefaultLocaleArgs,
+    ) : OpenRouterToolResult
+
+    @Serializable
+    data class ListStringResourcesArgs(
+        override val tool_name: String = "list_string_resources",
+        override val tool_call_id: String,
+        override val tool_args: ToolArgs.ListStringResourcesArgs,
+    ) : OpenRouterToolResult
+
+    @Serializable
+    data class GetStringResourceArgs(
+        override val tool_name: String = "get_string_resource",
+        override val tool_call_id: String,
+        override val tool_args: ToolArgs.GetStringResourceArgs,
+    ) : OpenRouterToolResult
+
+    @Serializable
+    data class GetSupportedLocalesArgs(
+        override val tool_name: String = "get_supported_locales",
+        override val tool_call_id: String,
+        override val tool_args: ToolArgs.GetSupportedLocalesArgs,
+    ) : OpenRouterToolResult
 }

--- a/core/ai/src/commonMain/kotlin/io/composeflow/ai/openrouter/tools/OpenRouterToolResultSerializer.kt
+++ b/core/ai/src/commonMain/kotlin/io/composeflow/ai/openrouter/tools/OpenRouterToolResultSerializer.kt
@@ -314,6 +314,78 @@ object OpenRouterToolResultSerializer : KSerializer<OpenRouterToolResult> {
                                 value.tool_args,
                             ),
                         )
+
+                    is OpenRouterToolResult.AddStringResourcesArgs ->
+                        put(
+                            "tool_args",
+                            json.encodeToJsonElement(
+                                ToolArgs.AddStringResourcesArgs.serializer(),
+                                value.tool_args,
+                            ),
+                        )
+
+                    is OpenRouterToolResult.DeleteStringResourcesArgs ->
+                        put(
+                            "tool_args",
+                            json.encodeToJsonElement(
+                                ToolArgs.DeleteStringResourcesArgs.serializer(),
+                                value.tool_args,
+                            ),
+                        )
+
+                    is OpenRouterToolResult.UpdateStringResourcesArgs ->
+                        put(
+                            "tool_args",
+                            json.encodeToJsonElement(
+                                ToolArgs.UpdateStringResourcesArgs.serializer(),
+                                value.tool_args,
+                            ),
+                        )
+
+                    is OpenRouterToolResult.UpdateSupportedLocalesArgs ->
+                        put(
+                            "tool_args",
+                            json.encodeToJsonElement(
+                                ToolArgs.UpdateSupportedLocalesArgs.serializer(),
+                                value.tool_args,
+                            ),
+                        )
+
+                    is OpenRouterToolResult.SetDefaultLocaleArgs ->
+                        put(
+                            "tool_args",
+                            json.encodeToJsonElement(
+                                ToolArgs.SetDefaultLocaleArgs.serializer(),
+                                value.tool_args,
+                            ),
+                        )
+
+                    is OpenRouterToolResult.ListStringResourcesArgs ->
+                        put(
+                            "tool_args",
+                            json.encodeToJsonElement(
+                                ToolArgs.ListStringResourcesArgs.serializer(),
+                                value.tool_args,
+                            ),
+                        )
+
+                    is OpenRouterToolResult.GetStringResourceArgs ->
+                        put(
+                            "tool_args",
+                            json.encodeToJsonElement(
+                                ToolArgs.GetStringResourceArgs.serializer(),
+                                value.tool_args,
+                            ),
+                        )
+
+                    is OpenRouterToolResult.GetSupportedLocalesArgs ->
+                        put(
+                            "tool_args",
+                            json.encodeToJsonElement(
+                                ToolArgs.GetSupportedLocalesArgs.serializer(),
+                                value.tool_args,
+                            ),
+                        )
                 }
             }
 
@@ -738,6 +810,110 @@ object OpenRouterToolResultSerializer : KSerializer<OpenRouterToolResult> {
                         processedToolArgsElement,
                     )
                 OpenRouterToolResult.GetScreenDetailsArgs(
+                    tool_name = toolName,
+                    tool_call_id = toolCallId,
+                    tool_args = toolArgs,
+                )
+            }
+
+            "add_string_resources" -> {
+                val toolArgs =
+                    json.decodeFromJsonElement(
+                        ToolArgs.AddStringResourcesArgs.serializer(),
+                        processedToolArgsElement,
+                    )
+                OpenRouterToolResult.AddStringResourcesArgs(
+                    tool_name = toolName,
+                    tool_call_id = toolCallId,
+                    tool_args = toolArgs,
+                )
+            }
+
+            "delete_string_resources" -> {
+                val toolArgs =
+                    json.decodeFromJsonElement(
+                        ToolArgs.DeleteStringResourcesArgs.serializer(),
+                        processedToolArgsElement,
+                    )
+                OpenRouterToolResult.DeleteStringResourcesArgs(
+                    tool_name = toolName,
+                    tool_call_id = toolCallId,
+                    tool_args = toolArgs,
+                )
+            }
+
+            "update_string_resources" -> {
+                val toolArgs =
+                    json.decodeFromJsonElement(
+                        ToolArgs.UpdateStringResourcesArgs.serializer(),
+                        processedToolArgsElement,
+                    )
+                OpenRouterToolResult.UpdateStringResourcesArgs(
+                    tool_name = toolName,
+                    tool_call_id = toolCallId,
+                    tool_args = toolArgs,
+                )
+            }
+
+            "update_supported_locales" -> {
+                val toolArgs =
+                    json.decodeFromJsonElement(
+                        ToolArgs.UpdateSupportedLocalesArgs.serializer(),
+                        processedToolArgsElement,
+                    )
+                OpenRouterToolResult.UpdateSupportedLocalesArgs(
+                    tool_name = toolName,
+                    tool_call_id = toolCallId,
+                    tool_args = toolArgs,
+                )
+            }
+
+            "set_default_locale" -> {
+                val toolArgs =
+                    json.decodeFromJsonElement(
+                        ToolArgs.SetDefaultLocaleArgs.serializer(),
+                        processedToolArgsElement,
+                    )
+                OpenRouterToolResult.SetDefaultLocaleArgs(
+                    tool_name = toolName,
+                    tool_call_id = toolCallId,
+                    tool_args = toolArgs,
+                )
+            }
+
+            "list_string_resources" -> {
+                val toolArgs =
+                    json.decodeFromJsonElement(
+                        ToolArgs.ListStringResourcesArgs.serializer(),
+                        processedToolArgsElement,
+                    )
+                OpenRouterToolResult.ListStringResourcesArgs(
+                    tool_name = toolName,
+                    tool_call_id = toolCallId,
+                    tool_args = toolArgs,
+                )
+            }
+
+            "get_string_resource" -> {
+                val toolArgs =
+                    json.decodeFromJsonElement(
+                        ToolArgs.GetStringResourceArgs.serializer(),
+                        processedToolArgsElement,
+                    )
+                OpenRouterToolResult.GetStringResourceArgs(
+                    tool_name = toolName,
+                    tool_call_id = toolCallId,
+                    tool_args = toolArgs,
+                )
+            }
+
+            "get_supported_locales" -> {
+                val toolArgs =
+                    json.decodeFromJsonElement(
+                        ToolArgs.GetSupportedLocalesArgs.serializer(),
+                        processedToolArgsElement,
+                    )
+                OpenRouterToolResult.GetSupportedLocalesArgs(
                     tool_name = toolName,
                     tool_call_id = toolCallId,
                     tool_args = toolArgs,

--- a/core/ai/src/commonMain/kotlin/io/composeflow/ai/openrouter/tools/ToolArgs.kt
+++ b/core/ai/src/commonMain/kotlin/io/composeflow/ai/openrouter/tools/ToolArgs.kt
@@ -217,6 +217,54 @@ sealed class ToolArgs {
     ) : ToolArgs()
 
     @Serializable
+    @SerialName("add_string_resources")
+    data class AddStringResourcesArgs(
+        val stringResourcesYaml: String,
+    ) : ToolArgs()
+
+    @Serializable
+    @SerialName("delete_string_resources")
+    data class DeleteStringResourcesArgs(
+        val stringResourceIds: String,
+    ) : ToolArgs()
+
+    @Serializable
+    @SerialName("update_string_resources")
+    data class UpdateStringResourcesArgs(
+        val stringResourceUpdatesYaml: String,
+    ) : ToolArgs()
+
+    @Serializable
+    @SerialName("update_supported_locales")
+    data class UpdateSupportedLocalesArgs(
+        val localesYaml: String,
+    ) : ToolArgs()
+
+    @Serializable
+    @SerialName("set_default_locale")
+    data class SetDefaultLocaleArgs(
+        val localeCode: String,
+    ) : ToolArgs()
+
+    @Serializable
+    @SerialName("list_string_resources")
+    data class ListStringResourcesArgs(
+        val dummy: String = "",
+    ) : ToolArgs()
+
+    @Serializable
+    @SerialName("get_string_resource")
+    data class GetStringResourceArgs(
+        val stringResourceId: String,
+    ) : ToolArgs()
+
+    @Serializable
+    @SerialName("get_supported_locales")
+    data class GetSupportedLocalesArgs(
+        val dummy: String = "",
+    ) : ToolArgs()
+
+    @Serializable
     data class FakeArgs(
         val fakeString: String = "fakeString",
     ) : ToolArgs()

--- a/core/model/src/commonMain/kotlin/io/composeflow/ai/LlmRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/ai/LlmRepository.kt
@@ -513,9 +513,35 @@ class LlmRepository(
             is ToolArgs.ListCustomEnumsArgs,
             is ToolArgs.GetProjectIssuesArgs,
             is ToolArgs.ListScreensArgs,
+            is ToolArgs.ListStringResourcesArgs,
+            is ToolArgs.GetSupportedLocalesArgs,
             -> {
                 // These have minimal content but potentially large results
                 estimatedSize += 50
+            }
+
+            is ToolArgs.AddStringResourcesArgs -> {
+                estimatedSize += toolArg.stringResourcesYaml.length
+            }
+
+            is ToolArgs.DeleteStringResourcesArgs -> {
+                estimatedSize += toolArg.stringResourceIds.length
+            }
+
+            is ToolArgs.UpdateStringResourcesArgs -> {
+                estimatedSize += toolArg.stringResourceUpdatesYaml.length
+            }
+
+            is ToolArgs.UpdateSupportedLocalesArgs -> {
+                estimatedSize += toolArg.localesYaml.length
+            }
+
+            is ToolArgs.SetDefaultLocaleArgs -> {
+                estimatedSize += toolArg.localeCode.length
+            }
+
+            is ToolArgs.GetStringResourceArgs -> {
+                estimatedSize += toolArg.stringResourceId.length
             }
 
             is ToolArgs.FakeArgs -> {

--- a/feature/string-editor/src/commonMain/kotlin/io/composeflow/ui/string/StringResourceEditorOperator.kt
+++ b/feature/string-editor/src/commonMain/kotlin/io/composeflow/ui/string/StringResourceEditorOperator.kt
@@ -71,15 +71,15 @@ class StringResourceEditorOperator {
                 "The YAML representation of StringResource(s) to be added. " +
                     "Can be a single StringResource or a list of StringResources. Keys will be made unique if necessary.",
         )
-        stringResourceYaml: String,
+        stringResourcesYaml: String,
     ): EventResult =
         try {
             // Try to parse as list first, fallback to single resource
             val stringResources =
                 try {
-                    decodeFromStringWithFallback<List<StringResource>>(stringResourceYaml)
+                    decodeFromStringWithFallback<List<StringResource>>(stringResourcesYaml)
                 } catch (_: Exception) {
-                    listOf(decodeFromStringWithFallback<StringResource>(stringResourceYaml))
+                    listOf(decodeFromStringWithFallback<StringResource>(stringResourcesYaml))
                 }
             addStringResources(project, stringResources)
         } catch (e: Exception) {
@@ -173,18 +173,18 @@ class StringResourceEditorOperator {
         project: Project,
         @LlmParam(
             description =
-                "The YAML representation of the updated StringResource(s). " +
-                    "Can be a single StringResource or a list of StringResources. Must include the ID of each resource to update.",
+                "The YAML representation of StringResourceUpdate(s). " +
+                    "Can be a single StringResourceUpdate or a list of StringResourceUpdate objects. Each update must include the ID of the resource to update.",
         )
-        stringResourceYaml: String,
+        stringResourceUpdatesYaml: String,
     ): EventResult =
         try {
             // Try to parse as list first, fallback to single resource
             val updates =
                 try {
-                    decodeFromStringWithFallback<List<StringResourceUpdate>>(stringResourceYaml)
+                    decodeFromStringWithFallback<List<StringResourceUpdate>>(stringResourceUpdatesYaml)
                 } catch (_: Exception) {
-                    listOf(decodeFromStringWithFallback<StringResourceUpdate>(stringResourceYaml))
+                    listOf(decodeFromStringWithFallback<StringResourceUpdate>(stringResourceUpdatesYaml))
                 }
             updateStringResources(project, updates)
         } catch (e: Exception) {

--- a/feature/string-editor/src/commonMain/kotlin/io/composeflow/ui/string/StringResourceEditorOperator.kt
+++ b/feature/string-editor/src/commonMain/kotlin/io/composeflow/ui/string/StringResourceEditorOperator.kt
@@ -33,9 +33,6 @@ import io.composeflow.serializer.encodeToString
 import io.composeflow.ui.EventResult
 import org.jetbrains.compose.resources.getString
 
-// TODO: Wire this class with ToolDispatcher to enable AI to edit string resources.
-//       https://github.com/ComposeFlow/ComposeFlow/issues/34
-
 /**
  * Handles operations related to string resource editor, such as adding, updating, or removing string resources.
  * Operations in this class are exposed to the LLM to allow them to call it as tools as well as used

--- a/feature/string-editor/src/commonMain/kotlin/io/composeflow/ui/string/StringResourceEditorOperator.kt
+++ b/feature/string-editor/src/commonMain/kotlin/io/composeflow/ui/string/StringResourceEditorOperator.kt
@@ -62,7 +62,11 @@ class StringResourceEditorOperator {
 
     @LlmTool(
         name = "add_string_resources",
-        "Adds one or more string resources to the project. String resources are used for internationalization and localization of text in the application.",
+        "Adds one or more string resources to the project. " +
+            "String resources are used for internationalization and localization of text in the application. " +
+            "The IDs for string resources are generated automatically. " +
+            "When you refer to an added string resource later, you need to use the ID, not the key. " +
+            "You can check the generated IDs using the list_string_resources tool.",
     )
     suspend fun onAddStringResources(
         project: Project,

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ai/ToolDispatcher.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ai/ToolDispatcher.kt
@@ -8,6 +8,7 @@ import io.composeflow.serializer.encodeToString
 import io.composeflow.ui.EventResult
 import io.composeflow.ui.appstate.AppStateEditorOperator
 import io.composeflow.ui.datatype.DataTypeEditorOperator
+import io.composeflow.ui.string.StringResourceEditorOperator
 import io.composeflow.ui.uibuilder.UiBuilderOperator
 import io.composeflow.ui.uibuilder.toScreenSummary
 
@@ -18,6 +19,7 @@ class ToolDispatcher(
     private val uiBuilderOperator: UiBuilderOperator = UiBuilderOperator(),
     private val appStateEditorOperator: AppStateEditorOperator = AppStateEditorOperator(),
     private val dataTypeEditorOperator: DataTypeEditorOperator = DataTypeEditorOperator(),
+    private val stringResourceEditorOperator: StringResourceEditorOperator = StringResourceEditorOperator(),
 ) {
     /**
      * Dispatches a tool execution request to the appropriate operator.
@@ -377,6 +379,103 @@ class ToolDispatcher(
                     Logger.e(e) { "Error getting screen details" }
                     toolArgs.result = "Error getting screen details: ${e.message}"
                     EventResult().apply { errorMessages.add("Failed to get screen details: ${e.message}") }
+                }
+            }
+
+            is ToolArgs.AddStringResourcesArgs -> {
+                val result =
+                    stringResourceEditorOperator.onAddStringResources(
+                        project,
+                        toolArgs.stringResourcesYaml,
+                    )
+                if (result.errorMessages.isNotEmpty()) {
+                    toolArgs.result = result.errorMessages.joinToString("; ")
+                }
+                result
+            }
+
+            is ToolArgs.DeleteStringResourcesArgs -> {
+                val result =
+                    stringResourceEditorOperator.onDeleteStringResources(
+                        project,
+                        toolArgs.stringResourceIds,
+                    )
+                if (result.errorMessages.isNotEmpty()) {
+                    toolArgs.result = result.errorMessages.joinToString("; ")
+                }
+                result
+            }
+
+            is ToolArgs.UpdateStringResourcesArgs -> {
+                val result =
+                    stringResourceEditorOperator.onUpdateStringResources(
+                        project,
+                        toolArgs.stringResourceUpdatesYaml,
+                    )
+                if (result.errorMessages.isNotEmpty()) {
+                    toolArgs.result = result.errorMessages.joinToString("; ")
+                }
+                result
+            }
+
+            is ToolArgs.UpdateSupportedLocalesArgs -> {
+                val result =
+                    stringResourceEditorOperator.onUpdateSupportedLocales(
+                        project,
+                        toolArgs.localesYaml,
+                    )
+                if (result.errorMessages.isNotEmpty()) {
+                    toolArgs.result = result.errorMessages.joinToString("; ")
+                }
+                result
+            }
+
+            is ToolArgs.SetDefaultLocaleArgs -> {
+                val result =
+                    stringResourceEditorOperator.onSetDefaultLocale(
+                        project,
+                        toolArgs.localeCode,
+                    )
+                if (result.errorMessages.isNotEmpty()) {
+                    toolArgs.result = result.errorMessages.joinToString("; ")
+                }
+                result
+            }
+
+            is ToolArgs.ListStringResourcesArgs -> {
+                try {
+                    val stringResourcesResult = stringResourceEditorOperator.onListStringResources(project)
+                    toolArgs.result = stringResourcesResult
+                    EventResult() // Success
+                } catch (e: Exception) {
+                    Logger.e(e) { "Error listing string resources" }
+                    toolArgs.result = "Error listing string resources: ${e.message}"
+                    EventResult().apply { errorMessages.add("Failed to list string resources: ${e.message}") }
+                }
+            }
+
+            is ToolArgs.GetStringResourceArgs -> {
+                try {
+                    val stringResourceResult =
+                        stringResourceEditorOperator.onGetStringResource(project, toolArgs.stringResourceId)
+                    toolArgs.result = stringResourceResult
+                    EventResult() // Success
+                } catch (e: Exception) {
+                    Logger.e(e) { "Error getting string resource" }
+                    toolArgs.result = "Error getting string resource: ${e.message}"
+                    EventResult().apply { errorMessages.add("Failed to get string resource: ${e.message}") }
+                }
+            }
+
+            is ToolArgs.GetSupportedLocalesArgs -> {
+                try {
+                    val supportedLocalesResult = stringResourceEditorOperator.onGetSupportedLocales(project)
+                    toolArgs.result = supportedLocalesResult
+                    EventResult() // Success
+                } catch (e: Exception) {
+                    Logger.e(e) { "Error getting supported locales" }
+                    toolArgs.result = "Error getting supported locales: ${e.message}"
+                    EventResult().apply { errorMessages.add("Failed to get supported locales: ${e.message}") }
                 }
             }
 

--- a/generate-jsonschema-cli/src/main/kotlin/io/composeflow/Main.kt
+++ b/generate-jsonschema-cli/src/main/kotlin/io/composeflow/Main.kt
@@ -4,13 +4,14 @@ import dev.adamko.kxstsgen.KxsTsGenerator
 import io.composeflow.ai.AiResponse
 import io.composeflow.ai.CreateProjectAiResponse
 import io.composeflow.model.project.Project
+import io.composeflow.model.project.string.StringResourceUpdate
 import java.io.File
 
 fun main() {
     println("Generating type script for ComposeFlow project...")
     val generator = KxsTsGenerator()
     val fileName = "composeflow.d.ts"
-    File(fileName).writeText(generator.generate(Project.serializer()))
+    File(fileName).writeText(generator.generate(Project.serializer(), StringResourceUpdate.serializer()))
     println("Project typescript file is generated at $fileName")
 
     val aiResponseFileName = "airesponse.d.ts"


### PR DESCRIPTION
Close #29.

I confirmed "Please add string resources for texts in Xxx screen" or "Translate texts in the Xxx screen" worked. LLM first defined necessary string resources, and updated traits of compose nodes to use the added string resources.

https://github.com/user-attachments/assets/baded472-1e33-4eae-b9cc-0d918348bcd5

### Remaining issue

If the screen contains icons and there are content descriptions for them, LLM can be trapped in a infinite loop. LLM tries to localize the content description, but since `contentDescription` of `IconTrait` is not an AssignableProperty but a String, we can't use StringResource for it. LLM listed project issues to figure our the issue which prevented it from translating content description, but the returned issue list is empty, so LLM just repeatedly list project issues and list string resources.