### PR TITLE
Fix invalid identifier

### DIFF
--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/CheckboxTrait.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/CheckboxTrait.kt
@@ -120,7 +120,7 @@ data class CheckboxTrait(
     override fun companionState(composeNode: ComposeNode): ScreenState<*> =
         ScreenState.BooleanScreenState(
             id = composeNode.companionStateId,
-            name = composeNode.label.value,
+            name = composeNode.labelExposed,
             companionNodeId = composeNode.id,
         )
 
@@ -129,7 +129,7 @@ data class CheckboxTrait(
         stateHolder: StateHolder,
         node: ComposeNode,
     ) {
-        node.label.value = stateHolder.createUniqueLabel(project, node, node.label.value)
+        node.setLabel(stateHolder.createUniqueLabel(project, node, node.labelExposed))
         node.trait.value =
             this.copy(checked = ValueFromCompanionState(node))
     }

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/ChipGroupTrait.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/ChipGroupTrait.kt
@@ -89,7 +89,7 @@ data class ChipGroupTrait(
     override fun companionState(composeNode: ComposeNode): ScreenState<*> =
         ScreenState.StringListScreenState(
             id = composeNode.companionStateId,
-            name = composeNode.label.value,
+            name = composeNode.labelExposed,
             companionNodeId = composeNode.id,
         )
 

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/DropdownTrait.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/DropdownTrait.kt
@@ -133,7 +133,7 @@ data class DropdownTrait(
     override fun companionState(composeNode: ComposeNode): ScreenState<*> =
         ScreenState.StringScreenState(
             id = composeNode.companionStateId,
-            name = composeNode.label.value,
+            name = composeNode.labelExposed,
             companionNodeId = composeNode.id,
         )
 
@@ -142,7 +142,7 @@ data class DropdownTrait(
         stateHolder: StateHolder,
         node: ComposeNode,
     ) {
-        node.label.value = stateHolder.createUniqueLabel(project, node, node.label.value)
+        node.setLabel(stateHolder.createUniqueLabel(project, node, node.labelExposed))
         node.trait.value =
             this.copy(selectedItem = ValueFromCompanionState(node))
     }

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/SliderTrait.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/SliderTrait.kt
@@ -127,7 +127,7 @@ data class SliderTrait(
     override fun companionState(composeNode: ComposeNode): ScreenState<*> =
         ScreenState.FloatScreenState(
             id = composeNode.companionStateId,
-            name = composeNode.label.value,
+            name = composeNode.labelExposed,
             companionNodeId = composeNode.id,
         )
 
@@ -136,7 +136,7 @@ data class SliderTrait(
         stateHolder: StateHolder,
         node: ComposeNode,
     ) {
-        node.label.value = stateHolder.createUniqueLabel(project, node, node.label.value)
+        node.setLabel(stateHolder.createUniqueLabel(project, node, node.labelExposed))
         node.trait.value =
             this.copy(value = ValueFromCompanionState(node))
     }

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/SwitchTrait.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/SwitchTrait.kt
@@ -120,7 +120,7 @@ data class SwitchTrait(
     override fun companionState(composeNode: ComposeNode): ScreenState<*> =
         ScreenState.BooleanScreenState(
             id = composeNode.companionStateId,
-            name = composeNode.label.value,
+            name = composeNode.labelExposed,
             companionNodeId = composeNode.id,
         )
 
@@ -129,7 +129,7 @@ data class SwitchTrait(
         stateHolder: StateHolder,
         node: ComposeNode,
     ) {
-        node.label.value = stateHolder.createUniqueLabel(project, node, node.label.value)
+        node.setLabel(stateHolder.createUniqueLabel(project, node, node.labelExposed))
         node.trait.value =
             this.copy(checked = ValueFromCompanionState(node))
     }

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/TextFieldTrait.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/TextFieldTrait.kt
@@ -82,7 +82,7 @@ data class TextFieldTrait(
     override fun companionState(composeNode: ComposeNode): ScreenState<*> =
         ScreenState.StringScreenState(
             id = composeNode.companionStateId,
-            name = composeNode.label.value,
+            name = composeNode.labelExposed,
             companionNodeId = composeNode.id,
         )
 
@@ -91,7 +91,7 @@ data class TextFieldTrait(
         stateHolder: StateHolder,
         node: ComposeNode,
     ) {
-        node.label.value = stateHolder.createUniqueLabel(project, node, node.label.value)
+        node.setLabel(stateHolder.createUniqueLabel(project, node, node.labelExposed))
         node.trait.value =
             this.copy(value = ValueFromCompanionState(node))
     }

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/project/appscreen/screen/Screen.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/project/appscreen/screen/Screen.kt
@@ -212,7 +212,7 @@ data class Screen(
             newRoot.addChild(rootNode.value)
             rootNode.value = newRoot
         }
-        rootNode.value.label.value = label.value
+        rootNode.value.setLabel(label.value)
 
         getAllComposeNodes().forEach { it.updateComposeNodeReferencesForTrait() }
 
@@ -289,7 +289,7 @@ data class Screen(
             getRootNode()
                 .allChildren()
                 .filter { it.id != composeNode.id }
-                .map { it.label.value }
+                .map { it.labelExposed }
                 .toSet()
         return generateUniqueName(
             initial = initial,

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/project/appscreen/screen/composenode/ComposeNode.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/project/appscreen/screen/composenode/ComposeNode.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.window.core.layout.WindowWidthSizeClass
 import com.charleskorn.kaml.YamlNode
+import io.composeflow.asVariableName
 import io.composeflow.eachEquals
 import io.composeflow.kotlinpoet.GenerationContext
 import io.composeflow.kotlinpoet.wrapper.CodeBlockWrapper
@@ -68,6 +69,7 @@ import io.composeflow.serializer.parseToYamlNode
 import io.composeflow.ui.CanvasNodeCallbacks
 import io.composeflow.ui.adaptive.computeWindowAdaptiveInfo
 import io.composeflow.ui.zoomablecontainer.ZoomableContainerStateHolder
+import io.composeflow.util.toKotlinFileName
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -81,7 +83,7 @@ data class ComposeNode(
     @Serializable(with = MutableStateSerializer::class)
     val trait: MutableState<ComposeTrait> = mutableStateOf(EmptyTrait),
     @Serializable(MutableStateSerializer::class)
-    val label: MutableState<String> = mutableStateOf(trait.value.iconText()),
+    private val label: MutableState<String> = mutableStateOf(trait.value.iconText()),
     /**
      * The level of this node in the tree. The root node's level is 0.
      * This is var intentionally because when the default ComposeNode has a child initially,
@@ -238,6 +240,15 @@ data class ComposeNode(
      */
     @Transient
     val companionStateId: StateId = "$id-companionState"
+
+    /**
+     * Exposed version of the label. To be safely passed to KotlinPoet's code generation,
+     * escape characters invalid in Kotlin.
+     */
+    val labelExposed = label.value.asVariableName()
+    fun setLabel(value: String) {
+        label.value = value
+    }
 
     fun displayName(project: Project): String =
         if (trait.value is ComponentTrait) {

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/project/appscreen/screen/composenode/ComposeNode.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/project/appscreen/screen/composenode/ComposeNode.kt
@@ -69,7 +69,6 @@ import io.composeflow.serializer.parseToYamlNode
 import io.composeflow.ui.CanvasNodeCallbacks
 import io.composeflow.ui.adaptive.computeWindowAdaptiveInfo
 import io.composeflow.ui.zoomablecontainer.ZoomableContainerStateHolder
-import io.composeflow.util.toKotlinFileName
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
@@ -246,6 +245,7 @@ data class ComposeNode(
      * escape characters invalid in Kotlin.
      */
     val labelExposed = label.value.asVariableName()
+
     fun setLabel(value: String) {
         label.value = value
     }

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/project/component/Component.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/project/component/Component.kt
@@ -350,7 +350,7 @@ data class Component(
             getRootNode()
                 .allChildren()
                 .filter { it.id != composeNode.id }
-                .map { it.label.value }
+                .map { it.labelExposed }
                 .toSet()
         return generateUniqueName(
             initial = initial,

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/property/AssignableProperty.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/property/AssignableProperty.kt
@@ -1412,7 +1412,7 @@ data class ValueFromDynamicItem(
     private fun textFromDynamicItem(project: Project): String {
         val unknownItem = "[Unknown dynamic item]"
         val composeNode = project.findComposeNodeOrNull(composeNodeId) ?: return unknownItem
-        return "[item: ${composeNode.label.value + fieldType.fieldName(project)}]"
+        return "[item: ${composeNode.labelExposed + fieldType.fieldName(project)}]"
     }
 
     private fun fieldNameAsViewModel(fieldName: String): String = fieldName.replace(".", "").replaceFirstChar { it.uppercase() }

--- a/core/model/src/jvmTest/kotlin/io/composeflow/model/project/appscreen/screen/ScreenTest.kt
+++ b/core/model/src/jvmTest/kotlin/io/composeflow/model/project/appscreen/screen/ScreenTest.kt
@@ -136,7 +136,7 @@ class ScreenTest {
         // Verify root node exists and has expected properties
         assertNotNull(screen.rootNode, "Root node should exist")
         assertEquals("editProfileScreen", screen.rootNode.value.id)
-        assertEquals("Edit Profile", screen.rootNode.value.label.value)
+        assertEquals("editProfile", screen.rootNode.value.labelExposed)
 
         // Verify the screen has the expected states
         val project = Project(name = "test")

--- a/core/ui/src/commonMain/kotlin/io/composeflow/ui/text/EditableText.kt
+++ b/core/ui/src/commonMain/kotlin/io/composeflow/ui/text/EditableText.kt
@@ -2,8 +2,10 @@ package io.composeflow.ui.text
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
@@ -12,6 +14,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -35,13 +38,10 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import io.composeflow.ui.icon.ComposeFlowIcon
-import io.composeflow.ui.icon.ComposeFlowIconButton
 import io.composeflow.editor.validator.InputValidator
 import io.composeflow.editor.validator.ValidateResult
-import androidx.compose.material3.Text
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
+import io.composeflow.ui.icon.ComposeFlowIcon
+import io.composeflow.ui.icon.ComposeFlowIconButton
 
 @Composable
 fun EditableText(
@@ -92,94 +92,94 @@ fun EditableText(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.padding(8.dp),
         ) {
-        Box(contentAlignment = Alignment.CenterStart) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                BasicTextField(
-                    value = tempText,
-                    onValueChange = { newText ->
-                        tempText = newText
-                        if (validator != null) {
-                            validationResult = validator.validate(newText)
-                        }
-                    },
-                    readOnly = !isEditable,
-                    singleLine = true,
-                    textStyle = textStyle,
-                    cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
-                    keyboardOptions =
-                        KeyboardOptions.Default.copy(
-                            imeAction = ImeAction.Done,
-                        ),
-                    keyboardActions =
-                        KeyboardActions(
-                            onDone = {
+            Box(contentAlignment = Alignment.CenterStart) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    BasicTextField(
+                        value = tempText,
+                        onValueChange = { newText ->
+                            tempText = newText
+                            if (validator != null) {
+                                validationResult = validator.validate(newText)
+                            }
+                        },
+                        readOnly = !isEditable,
+                        singleLine = true,
+                        textStyle = textStyle,
+                        cursorBrush = SolidColor(MaterialTheme.colorScheme.primary),
+                        keyboardOptions =
+                            KeyboardOptions.Default.copy(
+                                imeAction = ImeAction.Done,
+                            ),
+                        keyboardActions =
+                            KeyboardActions(
+                                onDone = {
+                                    onCommitChange()
+                                },
+                            ),
+                        modifier =
+                            Modifier
+                                .focusRequester(focusRequester)
+                                .defaultMinSize(minWidth = Dp.Unspecified)
+                                .drawUnderline(
+                                    isEditable,
+                                    color =
+                                        if (validationResult is ValidateResult.Failure) {
+                                            MaterialTheme.colorScheme.error
+                                        } else {
+                                            MaterialTheme.colorScheme.primary
+                                        },
+                                ).onPreviewKeyEvent { keyEvent ->
+                                    // Handle Escape key to cancel edit
+                                    if (isEditable && keyEvent.type == KeyEventType.KeyDown && keyEvent.key == Key.Escape) {
+                                        tempText = text
+                                        isEditable = false
+                                        focusManager.clearFocus()
+                                        true // Consume the event
+                                    } else {
+                                        false
+                                    }
+                                },
+                        interactionSource = interactionSource,
+                        decorationBox = { innerTextField ->
+                            Box(
+                                modifier = Modifier,
+                            ) {
+                                innerTextField()
+                            }
+                        },
+                    )
+
+                    if (isEditable) {
+                        ComposeFlowIconButton(
+                            onClick = {
                                 onCommitChange()
                             },
-                        ),
-                    modifier =
-                        Modifier
-                            .focusRequester(focusRequester)
-                            .defaultMinSize(minWidth = Dp.Unspecified)
-                            .drawUnderline(
-                                isEditable,
-                                color = if (validationResult is ValidateResult.Failure) {
-                                    MaterialTheme.colorScheme.error
-                                } else {
-                                    MaterialTheme.colorScheme.primary
-                                }
-                            )
-                            .onPreviewKeyEvent { keyEvent ->
-                                // Handle Escape key to cancel edit
-                                if (isEditable && keyEvent.type == KeyEventType.KeyDown && keyEvent.key == Key.Escape) {
-                                    tempText = text
-                                    isEditable = false
-                                    focusManager.clearFocus()
-                                    true // Consume the event
-                                } else {
-                                    false
-                                }
-                            },
-                    interactionSource = interactionSource,
-                    decorationBox = { innerTextField ->
-                        Box(
-                            modifier = Modifier,
                         ) {
-                            innerTextField()
+                            ComposeFlowIcon(
+                                imageVector = Icons.Default.Done,
+                                contentDescription = "Done",
+                            )
                         }
-                    },
-                )
-
-                if (isEditable) {
-                    ComposeFlowIconButton(
-                        onClick = {
-                            onCommitChange()
-                        },
-                    ) {
-                        ComposeFlowIcon(
-                            imageVector = Icons.Default.Done,
-                            contentDescription = "Done",
-                        )
                     }
                 }
             }
-        }
 
-        if (!isEditable) {
-            ComposeFlowIconButton(
-                onClick = {
-                    isEditable = true
-                    tempText = text
-                    focusRequester.requestFocus()
-                },
-            ) {
-                ComposeFlowIcon(
-                    imageVector = Icons.Default.Edit,
-                    contentDescription = "Edit",
-                )
+            if (!isEditable) {
+                ComposeFlowIconButton(
+                    onClick = {
+                        isEditable = true
+                        tempText = text
+                        focusRequester.requestFocus()
+                    },
+                ) {
+                    ComposeFlowIcon(
+                        imageVector = Icons.Default.Edit,
+                        contentDescription = "Edit",
+                    )
+                }
             }
-        }
         }
 
         // Show validation error message if any
@@ -189,9 +189,10 @@ fun EditableText(
                 text = currentValidationResult.message,
                 color = MaterialTheme.colorScheme.error,
                 style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier
-                    .padding(start = 8.dp, top = 2.dp, bottom = 4.dp)
-                    .fillMaxWidth(),
+                modifier =
+                    Modifier
+                        .padding(start = 8.dp, top = 2.dp, bottom = 4.dp)
+                        .fillMaxWidth(),
             )
         }
     }

--- a/desktopApp/src/jvmTest/kotlin/io/composeflow/AppBuilderTest.kt
+++ b/desktopApp/src/jvmTest/kotlin/io/composeflow/AppBuilderTest.kt
@@ -1326,7 +1326,7 @@ class AppBuilderTest {
 
         rootNode.addChild(
             TextFieldTrait().defaultComposeNode(project).apply {
-                label.value = "textField1"
+                setLabel("textField1")
             },
         )
         val editable = project.screenHolder.currentEditable()
@@ -1416,7 +1416,7 @@ class AppBuilderTest {
         rootNode.addChild(text)
         rootNode.addChild(
             SwitchTrait().defaultComposeNode(project).apply {
-                label.value = "switch1"
+                setLabel("switch1")
             },
         )
         val switchState = ScreenState.BooleanScreenState(name = "switch")
@@ -1469,7 +1469,7 @@ class AppBuilderTest {
         row.addChild(text)
         row.addChild(
             SwitchTrait().defaultComposeNode(project).apply {
-                label.value = "switch1"
+                setLabel("switch1")
             },
         )
         val switchState = ScreenState.BooleanScreenState(name = "switch")
@@ -1507,7 +1507,7 @@ class AppBuilderTest {
         rootNode.addChild(text)
         rootNode.addChild(
             SwitchTrait().defaultComposeNode(project).apply {
-                label.value = "switch1"
+                setLabel("switch1")
             },
         )
         val button = ButtonTrait().defaultComposeNode(project)
@@ -1515,7 +1515,7 @@ class AppBuilderTest {
 
         val textField =
             TextFieldTrait().defaultComposeNode(project).apply {
-                label.value = "textField1"
+                setLabel("textField1")
             }
         rootNode.addChild(textField)
         val switchState = ScreenState.BooleanScreenState(name = "switch")
@@ -1626,7 +1626,7 @@ class AppBuilderTest {
 
         val textField =
             TextFieldTrait().defaultComposeNode(project).apply {
-                label.value = "textField1"
+                setLabel("textField1")
             }
         rootNode.addChild(textField)
         val editable = project.screenHolder.currentEditable()
@@ -1995,7 +1995,7 @@ class AppBuilderTest {
             ComposeNode(
                 trait = mutableStateOf(TextFieldTrait()),
             ).apply {
-                label.value = "textField1"
+                setLabel("textField1")
             }
         val textFieldParams = textField1.trait.value as TextFieldTrait
 

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/inspector/PropertyInspector.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/inspector/PropertyInspector.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import io.composeflow.Res
+import io.composeflow.editor.validator.KotlinVariableNameValidator
 import io.composeflow.model.parameter.AbstractIconTrait
 import io.composeflow.model.parameter.BottomAppBarTrait
 import io.composeflow.model.parameter.BoxTrait
@@ -119,7 +120,6 @@ import io.composeflow.ui.modifier.hoverIconClickable
 import io.composeflow.ui.text.EditableText
 import io.composeflow.ui.utils.TreeExpanderInverse
 import org.jetbrains.compose.resources.stringResource
-import io.composeflow.editor.validator.KotlinVariableNameValidator
 
 @Composable
 fun PropertyInspector(

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/inspector/PropertyInspector.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/inspector/PropertyInspector.kt
@@ -119,6 +119,7 @@ import io.composeflow.ui.modifier.hoverIconClickable
 import io.composeflow.ui.text.EditableText
 import io.composeflow.ui.utils.TreeExpanderInverse
 import org.jetbrains.compose.resources.stringResource
+import io.composeflow.editor.validator.KotlinVariableNameValidator
 
 @Composable
 fun PropertyInspector(
@@ -266,10 +267,11 @@ fun ParamsInspector(
                     .hoverIconClickable(),
         ) {
             EditableText(
-                initialText = composeNode.label.value,
+                initialText = composeNode.labelExposed,
                 onValueChange = {
                     composeNodeCallbacks.onComposeNodeLabelUpdated(composeNode, it)
                 },
+                validator = KotlinVariableNameValidator(),
             )
             Spacer(modifier = Modifier.weight(1f))
 

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/inspector/lazylist/LazyListChildInspector.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/inspector/lazylist/LazyListChildInspector.kt
@@ -99,7 +99,7 @@ private fun DynamicSourceChildrenInspector(
     childParams: LazyListChildParams.DynamicItemsSource,
 ) {
     val lazyList =
-        childParams.getSourceId()?.let { node.findDependentDynamicItemsHolderOrNull(node, it) }
+        childParams.getSourceId().let { node.findDependentDynamicItemsHolderOrNull(node, it) }
             ?: return
     childParams.getNumOfItems(project, lazyList)
     BasicEditableTextProperty(
@@ -108,7 +108,7 @@ private fun DynamicSourceChildrenInspector(
                 project,
                 lazyList = lazyList,
             )
-        } [set from ${lazyList.label.value}]",
+        } [set from ${lazyList.labelExposed}]",
         label = "Items",
         enabled = false,
         onValidValueChanged = {},

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/toolbar/IssueBadge.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/toolbar/IssueBadge.kt
@@ -217,7 +217,7 @@ private fun IssuesPanel(
                                                             modifier = Modifier.size(20.dp),
                                                         )
                                                         Text(
-                                                            text = composeNode.label.value,
+                                                            text = composeNode.labelExposed,
                                                             style = MaterialTheme.typography.titleSmall,
                                                             color = MaterialTheme.colorScheme.onSurface,
                                                             modifier = Modifier.padding(start = 8.dp),

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/uibuilder/UiBuilderOperator.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/uibuilder/UiBuilderOperator.kt
@@ -412,8 +412,8 @@ class UiBuilderOperator {
         node?.let {
             val oldTrait = it.trait.value
             it.trait.value = trait
-            if (it.label.value == oldTrait.iconText()) {
-                it.label.value = trait.iconText()
+            if (it.labelExposed == oldTrait.iconText()) {
+                it.setLabel(trait.iconText())
             }
         }
     }

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/uibuilder/UiBuilderViewModel.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/uibuilder/UiBuilderViewModel.kt
@@ -264,7 +264,7 @@ class UiBuilderViewModel(
         try {
             focusedNodes.forEach { node ->
                 AnalyticsTracker.trackComposeNodeDeleted(
-                    nodeType = node.label.value,
+                    nodeType = node.labelExposed,
                     count = 1,
                 )
             }
@@ -799,7 +799,7 @@ class UiBuilderViewModel(
         )
         val currentEditable = project.screenHolder.currentEditable()
         val newLabel = currentEditable.createUniqueLabel(project, node, label)
-        node.label.value = newLabel
+        node.setLabel(newLabel)
 
         saveProject(project)
     }


### PR DESCRIPTION
Fixes #182 

    Fix the issue invalid identifier may be used for ComposeNode.label

    When a "." is used as part of the label of a ComposeNode, code
    generation stopped working because of the invalid identifier.

    This change prevents illegal characters from being used as part of the
    label