### PR TITLE
fix: Unnecessary recomposition when navigating

### DIFF
--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/navigationrail/LeftNavigationRail.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/navigationrail/LeftNavigationRail.kt
@@ -78,6 +78,8 @@ fun LeftNavigationRail(navigator: Navigator) {
                             .testTag("$NAVIGATION_RAIL_TEST_TAG/${item.name}"),
                     selected = isSelected,
                     onClick = {
+                        if (isSelected) return@NavigationRailItem
+
                         navigator.navigate(
                             item.route,
                             options =


### PR DESCRIPTION
Fixes #185 

Now, every time a navigation is triggered, it checks if the current screen is already selected. If it is, the function returns; otherwise, the navigation proceeds.