### PR TITLE
Fix the SettingRepository's persistent values are not shared

### DIFF
--- a/core/model/src/commonMain/kotlin/io/composeflow/model/settings/SettingsRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/settings/SettingsRepository.kt
@@ -132,7 +132,7 @@ class SettingsRepository(
             loadOnboardingStatus()
         }
     }
-    
+
     companion object {
         fun getInstance(): SettingsRepository = ServiceLocator.getOrPut { SettingsRepository() }
     }

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/settings/SettingsRepository.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/settings/SettingsRepository.kt
@@ -132,4 +132,8 @@ class SettingsRepository(
             loadOnboardingStatus()
         }
     }
+    
+    companion object {
+        fun getInstance(): SettingsRepository = ServiceLocator.getOrPut { SettingsRepository() }
+    }
 }

--- a/core/platform/build.gradle.kts
+++ b/core/platform/build.gradle.kts
@@ -35,6 +35,8 @@ kotlin {
             implementation(libs.kotlin.result)
             implementation(libs.kotlinx.atomicfu)
             implementation(libs.kotlinx.serialization.json)
+            implementation(libs.multiplatform.settings)
+            implementation(libs.multiplatform.settings.make.observable)
         }
 
         jvmTest.dependencies {
@@ -56,6 +58,7 @@ kotlin {
 
         wasmJsMain.dependencies {
             implementation(libs.ktor.client.js)
+            implementation(libs.multiplatform.settings.coroutines)
         }
 
         wasmJsTest.dependencies {

--- a/core/platform/src/wasmJsMain/kotlin/io/composeflow/datastore/DataStoreFactory.wasmJs.kt
+++ b/core/platform/src/wasmJsMain/kotlin/io/composeflow/datastore/DataStoreFactory.wasmJs.kt
@@ -1,11 +1,11 @@
 package io.composeflow.datastore
 
 import com.russhwolf.settings.ExperimentalSettingsApi
-import com.russhwolf.settings.StorageSettings
 import com.russhwolf.settings.ObservableSettings
-import com.russhwolf.settings.observable.makeObservable
+import com.russhwolf.settings.StorageSettings
 import com.russhwolf.settings.coroutines.FlowSettings
 import com.russhwolf.settings.coroutines.toFlowSettings
+import com.russhwolf.settings.observable.makeObservable
 import kotlinx.coroutines.flow.Flow
 
 actual object DataStoreFactory {
@@ -15,9 +15,7 @@ actual object DataStoreFactory {
      * Gets the singleton DataStore instance, creating it if necessary.
      * WASM implementation uses multiplatform-settings with localStorage for persistence.
      */
-    actual fun getOrCreateDataStore(producePath: () -> String): PlatformDataStore {
-        return dataStore ?: WasmDataStore().also { dataStore = it }
-    }
+    actual fun getOrCreateDataStore(producePath: () -> String): PlatformDataStore = dataStore ?: WasmDataStore().also { dataStore = it }
 }
 
 @OptIn(ExperimentalSettingsApi::class)
@@ -34,7 +32,7 @@ private class WasmDataStore : PlatformDataStore {
     }
 
     override suspend fun getString(key: String): String? = settings.getStringOrNull(key)
-    
+
     override fun observeString(key: String): Flow<String?> = flowSettings.getStringOrNullFlow(key)
 
     override suspend fun putBoolean(

--- a/core/platform/src/wasmJsMain/kotlin/io/composeflow/datastore/DataStoreFactory.wasmJs.kt
+++ b/core/platform/src/wasmJsMain/kotlin/io/composeflow/datastore/DataStoreFactory.wasmJs.kt
@@ -1,65 +1,65 @@
 package io.composeflow.datastore
 
+import com.russhwolf.settings.ExperimentalSettingsApi
+import com.russhwolf.settings.StorageSettings
+import com.russhwolf.settings.ObservableSettings
+import com.russhwolf.settings.observable.makeObservable
+import com.russhwolf.settings.coroutines.FlowSettings
+import com.russhwolf.settings.coroutines.toFlowSettings
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.map
 
-// TODO: Consider using multiplatform-settings as an alternative for DataStore in wasm
 actual object DataStoreFactory {
+    private var dataStore: PlatformDataStore? = null
+
     /**
      * Gets the singleton DataStore instance, creating it if necessary.
-     * WASM implementation provides a no-op in-memory store.
+     * WASM implementation uses multiplatform-settings with localStorage for persistence.
      */
-    actual fun getOrCreateDataStore(producePath: () -> String): PlatformDataStore = WasmDataStore()
+    actual fun getOrCreateDataStore(producePath: () -> String): PlatformDataStore {
+        return dataStore ?: WasmDataStore().also { dataStore = it }
+    }
 }
 
+@OptIn(ExperimentalSettingsApi::class)
 private class WasmDataStore : PlatformDataStore {
-    private val storage = mutableMapOf<String, Any>()
-    private val storageFlow = MutableStateFlow(storage.toMap())
-
-    private fun updateStorageFlow() {
-        storageFlow.value = storage.toMap()
-    }
+    // Use StorageSettings which persists to browser localStorage
+    private val settings: ObservableSettings = StorageSettings().makeObservable()
+    private val flowSettings: FlowSettings = settings.toFlowSettings()
 
     override suspend fun putString(
         key: String,
         value: String,
     ) {
-        storage[key] = value
-        updateStorageFlow()
+        settings.putString(key, value)
     }
 
-    override suspend fun getString(key: String): String? = storage[key] as? String
-
-    override fun observeString(key: String): Flow<String?> = storageFlow.map { it[key] as? String }
+    override suspend fun getString(key: String): String? = settings.getStringOrNull(key)
+    
+    override fun observeString(key: String): Flow<String?> = flowSettings.getStringOrNullFlow(key)
 
     override suspend fun putBoolean(
         key: String,
         value: Boolean,
     ) {
-        storage[key] = value
-        updateStorageFlow()
+        settings.putBoolean(key, value)
     }
 
-    override suspend fun getBoolean(key: String): Boolean? = storage[key] as? Boolean
+    override suspend fun getBoolean(key: String): Boolean? = settings.getBooleanOrNull(key)
 
     override suspend fun putInt(
         key: String,
         value: Int,
     ) {
-        storage[key] = value
-        updateStorageFlow()
+        settings.putInt(key, value)
     }
 
-    override suspend fun getInt(key: String): Int? = storage[key] as? Int
+    override suspend fun getInt(key: String): Int? = settings.getIntOrNull(key)
 
     override suspend fun remove(key: String) {
-        storage.remove(key)
-        updateStorageFlow()
+        settings.remove(key)
     }
 
     override suspend fun clear() {
-        storage.clear()
-        updateStorageFlow()
+        settings.clear()
     }
 }

--- a/desktopApp/src/jvmMain/kotlin/io/composeflow/TitleBarViewModel.kt
+++ b/desktopApp/src/jvmMain/kotlin/io/composeflow/TitleBarViewModel.kt
@@ -12,7 +12,7 @@ import moe.tlaster.precompose.viewmodel.ViewModel
 import moe.tlaster.precompose.viewmodel.viewModelScope
 
 class TitleBarViewModel(
-    private val settingsRepository: SettingsRepository = SettingsRepository(),
+    private val settingsRepository: SettingsRepository = SettingsRepository.getInstance(),
 ) : ViewModel() {
     /**
      * The content of the title bar.

--- a/feature/settings/src/commonMain/kotlin/io/composeflow/ui/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/io/composeflow/ui/settings/SettingsViewModel.kt
@@ -49,7 +49,7 @@ class SettingsViewModel(
     private val firebaseIdTokenArg: FirebaseIdToken,
     private val firebaseApiCaller: FirebaseApiCaller = FirebaseApiCaller(),
     private val authRepository: AuthRepository = AuthRepository(),
-    private val settingsRepository: SettingsRepository = SettingsRepository(),
+    private val settingsRepository: SettingsRepository = SettingsRepository.getInstance(),
     private val projectRepository: ProjectRepository = ProjectRepository(firebaseIdTokenArg),
 ) : ViewModel() {
     private val _firebaseApiResultState: MutableStateFlow<FirebaseApiResultState> =

--- a/feature/top/src/commonMain/kotlin/io/composeflow/ui/settings/AccountSettingsViewModel.kt
+++ b/feature/top/src/commonMain/kotlin/io/composeflow/ui/settings/AccountSettingsViewModel.kt
@@ -13,7 +13,7 @@ import moe.tlaster.precompose.viewmodel.ViewModel
 import moe.tlaster.precompose.viewmodel.viewModelScope
 
 class AccountSettingsViewModel(
-    private val settingsRepository: SettingsRepository = SettingsRepository(),
+    private val settingsRepository: SettingsRepository = SettingsRepository.getInstance(),
 ) : ViewModel() {
     val settings =
         settingsRepository.settings.stateIn(

--- a/feature/top/src/commonMain/kotlin/io/composeflow/ui/top/TopScreen.kt
+++ b/feature/top/src/commonMain/kotlin/io/composeflow/ui/top/TopScreen.kt
@@ -93,6 +93,8 @@ fun TopScreen(
 
     val projectUiState = viewModel.projectListUiState.collectAsState().value
 
+    println("settings dark theme settings: ${settings.value.composeBuilderDarkThemeSetting}")
+
     CompositionLocalProvider(LocalImageLoader provides ImageLoader.createDefault()) {
         ComposeFlowTheme(useDarkTheme = useComposeFlowDarkTheme) {
             ProvideTopScreenTheme(useDarkTheme = useComposeFlowDarkTheme) {

--- a/feature/top/src/commonMain/kotlin/io/composeflow/ui/top/TopScreenViewModel.kt
+++ b/feature/top/src/commonMain/kotlin/io/composeflow/ui/top/TopScreenViewModel.kt
@@ -30,7 +30,7 @@ class TopScreenViewModel(
         } else {
             ProjectRepository.createAnonymous()
         },
-    settingsRepository: SettingsRepository = SettingsRepository(),
+    settingsRepository: SettingsRepository = SettingsRepository.getInstance(),
     authRepository: AuthRepository = AuthRepository(),
 ) : ViewModel() {
     private val _projectListUiState: MutableStateFlow<ProjectUiState> =

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/toolbar/ToolbarViewModel.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/toolbar/ToolbarViewModel.kt
@@ -61,7 +61,7 @@ class ToolbarViewModel(
         },
     private val authRepository: AuthRepository = AuthRepository(),
     private val firebaseApiCaller: FirebaseApiCaller = FirebaseApiCaller(),
-    private val settingsRepository: SettingsRepository = SettingsRepository(),
+    private val settingsRepository: SettingsRepository = SettingsRepository.getInstance(),
     private val googleCloudStorageWrapper: GoogleCloudStorageWrapper = GoogleCloudStorageWrapper(),
     private val localAssetSaver: LocalAssetSaver = LocalAssetSaver(),
     private val assertSynchronizer: AssetSynchronizer =

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/uibuilder/UiBuilderViewModel.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/uibuilder/UiBuilderViewModel.kt
@@ -77,7 +77,7 @@ import kotlin.uuid.Uuid
 class UiBuilderViewModel(
     firebaseIdToken: FirebaseIdToken,
     private val project: Project,
-    private val settingsRepository: SettingsRepository = SettingsRepository(),
+    private val settingsRepository: SettingsRepository = SettingsRepository.getInstance(),
     private val projectRepository: ProjectRepository = ProjectRepository(firebaseIdToken),
     private val uiBuilderOperator: UiBuilderOperator = UiBuilderOperator(),
     private val onUpdateProject: (Project) -> Unit,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -108,11 +108,11 @@ kotlinx-serialization-jsonpath = "io.github.nomisrev:kotlinx-serialization-jsonp
 kotlin-result = "com.michael-bull.kotlin-result:kotlin-result:2.0.1"
 ktor-utils = "io.ktor:ktor-utils:3.2.3"
 kaml = "com.charleskorn.kaml:kaml:0.85.0"
-okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatform-settings" }
 multiplatform-settings-serialization = { module = "com.russhwolf:multiplatform-settings-serialization", version.ref = "multiplatform-settings" }
 multiplatform-settings-coroutines = { module = "com.russhwolf:multiplatform-settings-coroutines", version.ref = "multiplatform-settings" }
 multiplatform-settings-datastore = { module = "com.russhwolf:multiplatform-settings-datastore", version.ref = "multiplatform-settings" }
+multiplatform-settings-make-observable = { module = "com.russhwolf:multiplatform-settings-make-observable", version.ref = "multiplatform-settings" }
 
 # App Build
 compose-code-editor = "com.github.qawaz.compose-code-editor:codeeditor:v3.1.1"


### PR DESCRIPTION
Fixes #187.

SettingsRepository's persisted values are not shared across the app.
This PR changes the SettingsRepository as singleton and can be shared across the app.

Also introduce multiplatform-settings for the WASM implementation so that values are persisted in the localStorage.
