### PR TITLE
Add support for extended colors in theme

### DIFF
--- a/core/model/src/commonMain/kotlin/io/composeflow/model/color/ExtendedColor.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/color/ExtendedColor.kt
@@ -1,0 +1,13 @@
+package io.composeflow.model.color
+
+import androidx.compose.ui.graphics.Color
+import io.composeflow.serializer.LocationAwareColorSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@SerialName("ExtendedColor")
+data class ExtendedColor(
+    val name: String,
+    @Serializable(LocationAwareColorSerializer::class) val color: Color,
+)

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/project/theme/ColorSchemeHolder.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/project/theme/ColorSchemeHolder.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.Color
 import com.materialkolor.PaletteStyle
 import io.composeflow.kotlinpoet.wrapper.FileSpecWrapper
 import io.composeflow.model.color.ColorSchemeWrapper
+import io.composeflow.model.color.ExtendedColor
 import io.composeflow.model.project.COMPOSEFLOW_PACKAGE
 import io.composeflow.serializer.LocationAwareColorSerializer
 import io.composeflow.serializer.MutableStateSerializer
@@ -33,6 +34,8 @@ data class ColorSchemeHolder(
     @Serializable(MutableStateSerializer::class)
     val darkColorScheme: MutableState<ColorSchemeWrapper> =
         mutableStateOf(ColorSchemeWrapper.fromColorScheme(defaultDarkScheme)),
+    @Serializable(MutableStateSerializer::class)
+    val extendedColors: MutableState<List<ExtendedColor>> = mutableStateOf(emptyList()),
 ) {
     fun generateColorFile(): FileSpecWrapper {
         val fileSpecBuilder = FileSpecWrapper.builder("$COMPOSEFLOW_PACKAGE.common", "Color")
@@ -51,4 +54,5 @@ fun ColorSchemeHolder.copyContents(arg: ColorSchemeHolder) {
     paletteStyle = arg.paletteStyle
     lightColorScheme.value = arg.lightColorScheme.value
     darkColorScheme.value = arg.darkColorScheme.value
+    extendedColors.value = arg.extendedColors.value
 }

--- a/core/model/src/commonMain/kotlin/io/composeflow/ui/propertyeditor/AssignableBrushPropertyEditor.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/ui/propertyeditor/AssignableBrushPropertyEditor.kt
@@ -166,6 +166,7 @@ fun AssignableBrushPropertyEditor(
     if (showBrushEditDialog && brushWrapper != null && brushWrapper.colors.isNotEmpty()) {
         BrushEditDialog(
             initialBrush = brushWrapper,
+            extendedColors = project.themeHolder.colorSchemeHolder.extendedColors.value,
             onDismissRequest = { showBrushEditDialog = false },
             onConfirm = { newBrush ->
                 onValidPropertyChanged(BrushProperty.BrushIntrinsicValue(newBrush), null)

--- a/core/model/src/commonMain/kotlin/io/composeflow/ui/propertyeditor/AssignableColorPropertyEditor.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/ui/propertyeditor/AssignableColorPropertyEditor.kt
@@ -62,8 +62,9 @@ fun AssignableColorPropertyEditor(
             editable && (initialProperty is IntrinsicProperty<*> || initialProperty == null)
         if (editEnabled) {
             ColorPropertyEditor(
-                initialColor = (initialProperty as? ColorProperty.ColorIntrinsicValue)?.value,
                 label = label,
+                initialColor = (initialProperty as? ColorProperty.ColorIntrinsicValue)?.value,
+                extendedColors = project.themeHolder.colorSchemeHolder.extendedColors.value,
                 onColorUpdated = {
                     val newProperty =
                         ColorProperty.ColorIntrinsicValue(ColorWrapper(themeColor = null, color = it))

--- a/core/model/src/commonMain/kotlin/io/composeflow/ui/propertyeditor/BrushEditDialog.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/ui/propertyeditor/BrushEditDialog.kt
@@ -48,6 +48,7 @@ import io.composeflow.center_y
 import io.composeflow.edit_brush
 import io.composeflow.end_x
 import io.composeflow.end_y
+import io.composeflow.model.color.ExtendedColor
 import io.composeflow.model.parameter.wrapper.BrushType
 import io.composeflow.model.parameter.wrapper.BrushWrapper
 import io.composeflow.model.parameter.wrapper.ColorWrapper
@@ -68,6 +69,7 @@ import sh.calvin.reorderable.rememberReorderableLazyListState
 @Composable
 fun BrushEditDialog(
     initialBrush: BrushWrapper,
+    extendedColors: List<ExtendedColor>,
     onDismissRequest: () -> Unit,
     onConfirm: (BrushWrapper) -> Unit,
     modifier: Modifier = Modifier,
@@ -229,6 +231,7 @@ fun BrushEditDialog(
                                             editedBrush =
                                                 editedBrush.copy(colors = updatedColors)
                                         },
+                                        extendedColors = extendedColors,
                                         modifier = Modifier.weight(1f),
                                         includeThemeColor = true,
                                     )

--- a/core/model/src/commonMain/kotlin/io/composeflow/ui/propertyeditor/ColorPropertyEditor.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/ui/propertyeditor/ColorPropertyEditor.kt
@@ -53,6 +53,8 @@ import io.composeflow.Res
 import io.composeflow.cancel
 import io.composeflow.confirm
 import io.composeflow.delete_color
+import io.composeflow.extended_colors
+import io.composeflow.model.color.ExtendedColor
 import io.composeflow.model.parameter.wrapper.ColorWrapper
 import io.composeflow.model.parameter.wrapper.Material3ColorWrapper
 import io.composeflow.select_color
@@ -117,6 +119,7 @@ private fun String.toColorOrNull(): Color? =
 fun ColorPropertyEditor(
     label: String,
     initialColor: ColorWrapper?,
+    extendedColors: List<ExtendedColor>,
     onColorUpdated: (Color) -> Unit,
     onThemeColorSelected: (Material3ColorWrapper) -> Unit,
     modifier: Modifier = Modifier,
@@ -198,6 +201,7 @@ fun ColorPropertyEditor(
         onAnyDialogIsShown()
         ColorPropertyDialog(
             initialColor = initialColor,
+            extendedColors = extendedColors,
             onThemeColorSelected = onThemeColorSelected,
             onColorUpdated = onColorUpdated,
             onCloseClick = {
@@ -212,6 +216,7 @@ fun ColorPropertyEditor(
 @Composable
 private fun ColorPropertyDialog(
     initialColor: ColorWrapper?,
+    extendedColors: List<ExtendedColor>,
     onThemeColorSelected: (Material3ColorWrapper) -> Unit,
     onColorUpdated: (Color) -> Unit,
     onCloseClick: () -> Unit,
@@ -240,6 +245,7 @@ private fun ColorPropertyDialog(
         ) {
             ColorPropertyDialogContent(
                 initialColor = initialColor,
+                extendedColors = extendedColors,
                 onThemeColorSelected = onThemeColorSelected,
                 onCloseClick = onCloseClick,
                 onColorUpdated = onColorUpdated,
@@ -252,6 +258,7 @@ private fun ColorPropertyDialog(
 @Composable
 fun ColorPropertyDialogContent(
     initialColor: ColorWrapper?,
+    extendedColors: List<ExtendedColor>,
     onThemeColorSelected: (Material3ColorWrapper) -> Unit,
     onCloseClick: () -> Unit,
     onColorUpdated: (Color) -> Unit,
@@ -341,12 +348,12 @@ fun ColorPropertyDialogContent(
                 }
             }
 
-            if (includeThemeColor) {
-                LazyVerticalGrid(
-                    columns = GridCells.Adaptive(148.dp),
-                    modifier = Modifier.weight(1f),
-                    contentPadding = PaddingValues(16.dp),
-                ) {
+            LazyVerticalGrid(
+                columns = GridCells.Adaptive(148.dp),
+                modifier = Modifier.weight(1f),
+                contentPadding = PaddingValues(16.dp),
+            ) {
+                if (includeThemeColor) {
                     item(
                         span = {
                             GridItemSpan(maxLineSpan)
@@ -407,6 +414,58 @@ fun ColorPropertyDialogContent(
                                         ),
                             )
                         }
+                    }
+                }
+                item(
+                    span = {
+                        GridItemSpan(maxLineSpan)
+                    },
+                ) {
+                    Text(
+                        text = stringResource(Res.string.extended_colors),
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(start = 8.dp),
+                    )
+                }
+
+                items(
+                    extendedColors,
+                ) { extendedColor ->
+
+                    Row(
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier =
+                            Modifier
+                                .size(
+                                    width = 164.dp,
+                                    height = 64.dp,
+                                ).padding(8.dp)
+                                .background(
+                                    color = extendedColor.color,
+                                    shape = RoundedCornerShape(8.dp),
+                                ).border(
+                                    width = 1.dp,
+                                    color = MaterialTheme.colorScheme.surfaceVariant,
+                                    shape = RoundedCornerShape(8.dp),
+                                ).clickable {
+                                    onColorUpdated(extendedColor.color)
+                                    onCloseClick()
+                                }.hoverIconClickable(),
+                    ) {
+                        Text(
+                            text = extendedColor.name,
+                            color = Color.Black,
+                            style = MaterialTheme.typography.labelSmall,
+                            modifier =
+                                Modifier
+                                    .padding(
+                                        start = 8.dp,
+                                        top = 8.dp,
+                                        end = 8.dp,
+                                        bottom = 8.dp,
+                                    ),
+                        )
                     }
                 }
             }
@@ -512,6 +571,7 @@ private fun ThemedColorPropertyEditorPreview(useDarkTheme: Boolean) {
         ColorPropertyEditor(
             label = "Background Color",
             initialColor = ColorWrapper(Material3ColorWrapper.Primary),
+            extendedColors = listOf(),
             onColorUpdated = {},
             onThemeColorSelected = {},
             onColorDeleted = {},
@@ -539,6 +599,7 @@ private fun ThemedColorPropertyDialogContentPreview(
     ComposeFlowTheme(useDarkTheme = useDarkTheme) {
         ColorPropertyDialogContent(
             initialColor = ColorWrapper(Material3ColorWrapper.PrimaryContainer),
+            extendedColors = listOf(),
             onThemeColorSelected = {},
             onCloseClick = {},
             onColorUpdated = {},

--- a/core/resources/src/commonMain/composeResources/values/strings.xml
+++ b/core/resources/src/commonMain/composeResources/values/strings.xml
@@ -393,6 +393,12 @@ instead of in the canvas.</string>
     <string name="tap_to_show">Tap to show</string>
     <string name="toggle_value">Toggle value</string>
     <string name="theme_colors">Theme colors</string>
+    <string name="extended_colors">Extended colors</string>
+    <string name="add_a_color">Add a color</string>
+    <string name="color_name">Color name</string>
+    <string name="edit_color">Edit Color</string>
+    <string name="harmonize">Harmonize</string>
+    <string name="rename">Rename</string>
     <string name="to_string">To String</string>
     <string name="toggle_visibility">Toggle visibility</string>
     <string name="tooltip_show_topappbar">Toggle the visibility of the screen specific TopAppBar.\n

--- a/feature/settings/src/commonMain/kotlin/io/composeflow/ui/settings/appassets/AppAssetsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/io/composeflow/ui/settings/appassets/AppAssetsScreen.kt
@@ -288,6 +288,7 @@ fun AndroidSplashScreenEditorArea(
                         } else {
                             null
                         },
+                    extendedColors = project.themeHolder.colorSchemeHolder.extendedColors.value,
                     onColorUpdated = {
                         callbacks.onChangeAndroidSplashBackgroundColor(it)
                     },
@@ -415,6 +416,7 @@ fun IosSplashScreenEditorArea(
                         } else {
                             null
                         },
+                    extendedColors = project.themeHolder.colorSchemeHolder.extendedColors.value,
                     onColorUpdated = {
                         callbacks.onChangeIosSplashBackgroundColor(it)
                     },

--- a/feature/theme-editor/src/commonMain/kotlin/io/composeflow/ui/themeeditor/ColorEditorContent.kt
+++ b/feature/theme-editor/src/commonMain/kotlin/io/composeflow/ui/themeeditor/ColorEditorContent.kt
@@ -38,9 +38,11 @@ import androidx.compose.material.icons.automirrored.outlined.Redo
 import androidx.compose.material.icons.automirrored.outlined.Undo
 import androidx.compose.material.icons.filled.ModeNight
 import androidx.compose.material.icons.filled.WbSunny
+import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ColorScheme
@@ -70,6 +72,7 @@ import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.colorspace.ColorSpaces
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
@@ -88,21 +91,30 @@ import com.github.skydoves.colorpicker.compose.AlphaTile
 import com.github.skydoves.colorpicker.compose.HsvColorPicker
 import com.github.skydoves.colorpicker.compose.rememberColorPickerController
 import com.materialkolor.PaletteStyle
+import com.materialkolor.blend.Blend
 import com.materialkolor.dynamicColorScheme
 import com.materialkolor.ktx.toneColor
 import com.materialkolor.palettes.CorePalette
 import io.composeflow.Res
+import io.composeflow.add_a_color
 import io.composeflow.cancel
 import io.composeflow.chane_to_day_theme
 import io.composeflow.chane_to_night_theme
+import io.composeflow.color_name
 import io.composeflow.confirm
 import io.composeflow.dark_scheme
+import io.composeflow.delete
+import io.composeflow.edit_color
+import io.composeflow.extended_colors
+import io.composeflow.harmonize
 import io.composeflow.keyboard.getCtrlKeyStr
 import io.composeflow.light_scheme
+import io.composeflow.model.color.ExtendedColor
 import io.composeflow.model.palette.PaletteRenderParams
 import io.composeflow.model.parameter.wrapper.Material3ColorWrapper
 import io.composeflow.model.project.Project
 import io.composeflow.redo
+import io.composeflow.rename
 import io.composeflow.reset
 import io.composeflow.reset_to_default_colors
 import io.composeflow.seed_color
@@ -117,12 +129,14 @@ import io.composeflow.ui.adaptive.ProvideDeviceSizeDp
 import io.composeflow.ui.background.DotPatternBackground
 import io.composeflow.ui.common.AppTheme
 import io.composeflow.ui.common.ProvideAppThemeTokens
+import io.composeflow.ui.dropdown.PlatformCursorDropdownMenu
 import io.composeflow.ui.emptyCanvasNodeCallbacks
 import io.composeflow.ui.icon.ComposeFlowIcon
 import io.composeflow.ui.modifier.backgroundContainerNeutral
 import io.composeflow.ui.modifier.hoverIconClickable
 import io.composeflow.ui.popup.PositionCustomizablePopup
 import io.composeflow.ui.popup.SimpleConfirmationDialog
+import io.composeflow.ui.popup.SingleTextInputDialog
 import io.composeflow.ui.propertyeditor.BasicDropdownPropertyEditor
 import io.composeflow.ui.propertyeditor.ColorPreviewInfo
 import io.composeflow.ui.switch.ComposeFlowSwitch
@@ -184,6 +198,9 @@ fun ColorEditorContent(
                 mutableStateOf(
                     colorSchemeHolder.darkColorScheme.value.toColorScheme(),
                 )
+            }
+            val extendedColors by remember(colorSchemeHolder.extendedColors.value) {
+                mutableStateOf(colorSchemeHolder.extendedColors.value)
             }
             var syncSchemes by remember { mutableStateOf(true) }
             var schemeInEdit by remember { mutableStateOf(ColorSchemeType.Light) }
@@ -247,16 +264,17 @@ fun ColorEditorContent(
                 onSchemeInEditChanged = {
                     schemeInEdit = it
                 },
-                onShowSnackbar = { message, action ->
-                    coroutineScope.launch {
-                        onShowSnackbar(message, action)
-                    }
-                },
-            )
+            ) { message, action ->
+                coroutineScope.launch {
+                    onShowSnackbar(message, action)
+                }
+            }
             ColorSchemeDetailsContainer(
                 lightScheme = lightScheme,
                 darkScheme = darkScheme,
                 syncSchemes = syncSchemes,
+                sourceColor = sourceColor,
+                extendedColors = extendedColors,
                 onChangeScheme = { (light, dark) ->
                     lightScheme = light
                     darkScheme = dark
@@ -269,6 +287,18 @@ fun ColorEditorContent(
                         )
                         onShowSnackbar(updateColorSchemes, null)
                     }
+                },
+                onRenameExtendedColor = { extendedColor, newName ->
+                    callbacks.onRenameExtendedColor(extendedColor, newName)
+                },
+                onDeleteExtendedColor = {
+                    callbacks.onDeleteExtendedColor(it)
+                },
+                onChangeExtendedColor = { extendedColor, newColor ->
+                    callbacks.onChangeExtendedColor(
+                        extendedColor,
+                        extendedColor.copy(color = newColor),
+                    )
                 },
             )
             CanvasPreview(
@@ -312,6 +342,9 @@ private fun ColorSchemeEditor(
     var colorInEdit by remember { mutableStateOf(false) }
     var resetToDefaultColorsDialogOpen by remember { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
+    var addNewColorDialogOpen by remember { mutableStateOf(false) }
+    val onAnyDialogIsShown = LocalOnAnyDialogIsShown.current
+    val onAllDialogsClosed = LocalOnAllDialogsClosed.current
 
     Column(
         modifier =
@@ -354,10 +387,6 @@ private fun ColorSchemeEditor(
                 )
             }
         }
-        Spacer(
-            modifier = Modifier.height(16.dp),
-        )
-        HorizontalDivider()
         if (colorInEdit) {
             Column(modifier = Modifier.animateContentSize(keyframes { durationMillis = 100 })) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
@@ -462,10 +491,60 @@ private fun ColorSchemeEditor(
                 Text(stringResource(Res.string.update_colors))
             }
         }
+        Spacer(
+            modifier = Modifier.height(10.dp),
+        )
+        HorizontalDivider()
+        Spacer(
+            modifier = Modifier.height(10.dp),
+        )
+        Text(
+            text = stringResource(Res.string.extended_colors),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+
+        TextButton(
+            onClick = {
+                addNewColorDialogOpen = true
+            },
+            modifier = Modifier.padding(top = 5.dp),
+        ) {
+            ComposeFlowIcon(
+                imageVector = Icons.Outlined.Add,
+                contentDescription = null,
+                modifier = Modifier.padding(end = 4.dp),
+            )
+            Text(
+                text = stringResource(Res.string.add_a_color),
+            )
+        }
+
+        val onAnyDialogIsShown = LocalOnAnyDialogIsShown.current
+        val onAllDialogsClosed = LocalOnAllDialogsClosed.current
+        if (addNewColorDialogOpen) {
+            onAnyDialogIsShown()
+
+            val onCloseDialog = {
+                onAllDialogsClosed()
+                addNewColorDialogOpen = false
+            }
+            SingleTextInputDialog(
+                textLabel = stringResource(Res.string.color_name),
+                onTextConfirmed = { name ->
+                    callbacks.onAddNewExtendedColor(
+                        ExtendedColor(
+                            name = name,
+                            color = darkScheme.primary,
+                        ),
+                    )
+                    onCloseDialog()
+                },
+                onDismissDialog = onCloseDialog,
+            )
+        }
     }
 
-    val onAnyDialogIsShown = LocalOnAnyDialogIsShown.current
-    val onAllDialogsClosed = LocalOnAllDialogsClosed.current
     if (resetToDefaultColorsDialogOpen) {
         onAnyDialogIsShown()
         val closeDialog = {
@@ -718,8 +797,13 @@ val sampleColors =
 private fun ColorSchemeDetailsContainer(
     lightScheme: ColorScheme,
     darkScheme: ColorScheme,
+    sourceColor: Color?,
+    extendedColors: List<ExtendedColor>,
     syncSchemes: Boolean,
     onChangeScheme: (Pair<ColorScheme, ColorScheme>) -> Unit,
+    onChangeExtendedColor: (ExtendedColor, Color) -> Unit,
+    onRenameExtendedColor: (ExtendedColor, String) -> Unit,
+    onDeleteExtendedColor: (ExtendedColor) -> Unit,
 ) {
     LazyColumn(modifier = Modifier.wrapContentWidth()) {
         item {
@@ -767,6 +851,17 @@ private fun ColorSchemeDetailsContainer(
                     },
                 )
             }
+        }
+
+        item {
+            ExtendedColorPalette(
+                extendedColors = extendedColors,
+                colorScheme = darkScheme,
+                sourceColor = sourceColor,
+                onColorChanged = onChangeExtendedColor,
+                onRename = onRenameExtendedColor,
+                onDelete = onDeleteExtendedColor,
+            )
         }
     }
 }
@@ -1017,6 +1112,123 @@ private fun VerticalColorsPalette(
 }
 
 @Composable
+private fun ExtendedColorPalette(
+    extendedColors: List<ExtendedColor>,
+    colorScheme: ColorScheme,
+    sourceColor: Color?,
+    onColorChanged: (ExtendedColor, Color) -> Unit,
+    onRename: (ExtendedColor, String) -> Unit,
+    onDelete: (ExtendedColor) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val focusRequester = remember { FocusRequester() }
+    val onAnyDialogIsShown = LocalOnAnyDialogIsShown.current
+    val onAllDialogsClosed = LocalOnAllDialogsClosed.current
+    var colorPickerDialogOpen by remember { mutableStateOf(false) }
+    var renameColorDialogOpen by remember { mutableStateOf(false) }
+    var colorSelected by remember {
+        mutableStateOf<ExtendedColor?>(null)
+    }
+
+    Column(
+        modifier =
+            Modifier
+                .padding(16.dp)
+                .background(
+                    colorScheme.surface,
+                    shape = RoundedCornerShape(8.dp),
+                ).border(
+                    width = 1.dp,
+                    color = colorScheme.outline,
+                    shape = RoundedCornerShape(8.dp),
+                ).focusProperties { canFocus = true }
+                .focusRequester(focusRequester),
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp).width(820.dp),
+        ) {
+            Text(
+                text = stringResource(Res.string.extended_colors),
+                style = MaterialTheme.typography.titleSmall,
+                color = colorScheme.onSurface,
+                modifier = Modifier.padding(bottom = 16.dp),
+            )
+            FlowRow(
+                modifier = modifier,
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                maxItemsInEachRow = 4,
+            ) {
+                extendedColors.forEach { extendedColor ->
+                    ExtendedColorBox(
+                        modifier = modifier.size(205.dp, 60.dp),
+                        extendedColor = extendedColor,
+                        onRename = {
+                            colorSelected = extendedColor
+                            renameColorDialogOpen = true
+                        },
+                        onDelete = {
+                            onDelete(extendedColor)
+                        },
+                        onEditColor = {
+                            colorSelected = extendedColor
+                            colorPickerDialogOpen = true
+                        },
+                        onHarmonize = {
+                            val designColorArgb = extendedColor.color.toArgb()
+                            val sourceColorArgb = (sourceColor ?: colorScheme.primary).toArgb()
+                            val newColorArgb = Blend.harmonize(designColorArgb, sourceColorArgb)
+                            val newColor = Color(newColorArgb)
+                            onColorChanged(extendedColor, newColor)
+                        },
+                    )
+                }
+            }
+        }
+    }
+
+    when {
+        colorPickerDialogOpen && colorSelected != null -> {
+            onAnyDialogIsShown()
+
+            ColorPickerDialog(
+                initialColor = colorSelected!!.color,
+                onCloseClick = {
+                    colorPickerDialogOpen = false
+                    colorSelected = null
+                    onAllDialogsClosed()
+                },
+                onColorConfirmed = {
+                    onColorChanged(colorSelected!!, it)
+                    onAllDialogsClosed()
+                    focusRequester.requestFocus()
+                },
+            )
+        }
+
+        renameColorDialogOpen && colorSelected != null -> {
+            onAnyDialogIsShown()
+
+            val onCloseDialog: () -> Unit = {
+                onAllDialogsClosed()
+                renameColorDialogOpen = false
+                focusRequester.requestFocus()
+            }
+            SingleTextInputDialog(
+                textLabel = stringResource(Res.string.color_name),
+                initialValue = colorSelected!!.name,
+                onTextConfirmed = { name ->
+                    if (name.isNotBlank() && extendedColors.none { it.name == name }) {
+                        onRename(colorSelected!!, name)
+                    }
+                    onCloseDialog()
+                },
+                onDismissDialog = onCloseDialog,
+            )
+        }
+    }
+}
+
+@Composable
 private fun ColorBox(
     color: Material3ColorWrapper,
     onClick: () -> Unit,
@@ -1068,6 +1280,111 @@ private fun ColorBox(
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun ExtendedColorBox(
+    extendedColor: ExtendedColor,
+    onRename: () -> Unit,
+    onDelete: () -> Unit,
+    onEditColor: () -> Unit,
+    onHarmonize: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val contentColor =
+        remember(extendedColor.color) {
+            val luminance = extendedColor.color.luminance()
+            val tone = if (luminance > 0.5f) 20 else 90
+            CorePalette.contentOf(extendedColor.color.toArgb()).a1.toneColor(tone)
+        }
+
+    val isHovered by interactionSource.collectIsHoveredAsState()
+    val backgroundColor = extendedColor.color
+    var showMenu by remember { mutableStateOf(false) }
+
+    Box(
+        modifier = modifier,
+    ) {
+        SelectionContainer {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(backgroundColor.copy(alpha = if (isHovered) 0.9f else 1f))
+                        .hoverable(interactionSource),
+            ) {
+                Text(
+                    text = extendedColor.name,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = contentColor,
+                    modifier = Modifier.align(Alignment.TopStart).padding(8.dp),
+                )
+
+                Text(
+                    text = backgroundColor.asString(),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = contentColor,
+                    modifier = Modifier.align(Alignment.BottomEnd).padding(8.dp),
+                )
+
+                AnimatedVisibility(
+                    visible = isHovered,
+                    enter = fadeIn(),
+                    exit = fadeOut(),
+                    modifier = Modifier.align(Alignment.TopEnd),
+                ) {
+                    IconButton(
+                        onClick = {
+                            showMenu = true
+                        },
+                    ) {
+                        ComposeFlowIcon(
+                            imageVector = Icons.Rounded.MoreVert,
+                            contentDescription = null,
+                            tint = contentColor,
+                        )
+                    }
+                }
+            }
+        }
+        PlatformCursorDropdownMenu(
+            expanded = showMenu,
+            onDismissRequest = { showMenu = false },
+            modifier = Modifier.background(color = MaterialTheme.colorScheme.surface),
+        ) {
+            DropdownMenuItem(text = {
+                Text(text = stringResource(Res.string.edit_color))
+            }, onClick = {
+                showMenu = false
+                onEditColor()
+            })
+
+            DropdownMenuItem(text = {
+                Text(text = stringResource(Res.string.harmonize))
+            }, onClick = {
+                showMenu = false
+                onHarmonize()
+            })
+
+            DropdownMenuItem(text = {
+                Text(text = stringResource(Res.string.rename))
+            }, onClick = {
+                showMenu = false
+                onRename()
+            })
+
+            DropdownMenuItem(text = {
+                Text(
+                    text = stringResource(Res.string.delete),
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }, onClick = {
+                showMenu = false
+                onDelete()
+            })
         }
     }
 }

--- a/feature/theme-editor/src/commonMain/kotlin/io/composeflow/ui/themeeditor/ThemeEditorCallbacks.kt
+++ b/feature/theme-editor/src/commonMain/kotlin/io/composeflow/ui/themeeditor/ThemeEditorCallbacks.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEvent
 import com.materialkolor.PaletteStyle
 import io.composeflow.font.FontFamilyWrapper
+import io.composeflow.model.color.ExtendedColor
 import io.composeflow.model.enumwrapper.TextStyleWrapper
 import io.composeflow.model.project.theme.TextStyleOverride
 import io.composeflow.ui.EventResult
@@ -25,4 +26,8 @@ data class ThemeEditorCallbacks(
     val onKeyPressed: (KeyEvent) -> EventResult,
     val onUndo: () -> Unit,
     val onRedo: () -> Unit,
+    val onAddNewExtendedColor: (extendedColor: ExtendedColor) -> Unit,
+    val onChangeExtendedColor: (extendedColor: ExtendedColor, newExtendedColor: ExtendedColor) -> Unit,
+    val onRenameExtendedColor: (extendedColor: ExtendedColor, newName: String) -> Unit,
+    val onDeleteExtendedColor: (extendedColor: ExtendedColor) -> Unit,
 )

--- a/feature/theme-editor/src/commonMain/kotlin/io/composeflow/ui/themeeditor/ThemeEditorScreen.kt
+++ b/feature/theme-editor/src/commonMain/kotlin/io/composeflow/ui/themeeditor/ThemeEditorScreen.kt
@@ -66,6 +66,10 @@ fun ThemeEditorScreen(
             onKeyPressed = viewModel::onKeyPressed,
             onUndo = viewModel::onUndo,
             onRedo = viewModel::onRedo,
+            onAddNewExtendedColor = viewModel::onAddNewExtendedColor,
+            onChangeExtendedColor = viewModel::onChangeExtendedColor,
+            onRenameExtendedColor = viewModel::onRenameExtendedColor,
+            onDeleteExtendedColor = viewModel::onDeleteExtendedColor,
         )
     val fontEditableParams =
         FontEditableParams(

--- a/feature/theme-editor/src/commonMain/kotlin/io/composeflow/ui/themeeditor/ThemeEditorViewModel.kt
+++ b/feature/theme-editor/src/commonMain/kotlin/io/composeflow/ui/themeeditor/ThemeEditorViewModel.kt
@@ -16,6 +16,7 @@ import com.materialkolor.PaletteStyle
 import io.composeflow.auth.FirebaseIdToken
 import io.composeflow.font.FontFamilyWrapper
 import io.composeflow.model.color.ColorSchemeWrapper
+import io.composeflow.model.color.ExtendedColor
 import io.composeflow.model.enumwrapper.TextStyleWrapper
 import io.composeflow.model.project.Project
 import io.composeflow.model.project.theme.ColorSchemeHolder
@@ -27,6 +28,7 @@ import io.composeflow.repository.ProjectRepository
 import io.composeflow.ui.EventResult
 import io.composeflow.ui.common.defaultDarkScheme
 import io.composeflow.ui.common.defaultLightScheme
+import io.composeflow.util.generateUniqueName
 import kotlinx.coroutines.launch
 import moe.tlaster.precompose.viewmodel.ViewModel
 import moe.tlaster.precompose.viewmodel.viewModelScope
@@ -79,6 +81,63 @@ class ThemeEditorViewModel(
         }
 
         saveProject()
+    }
+
+    fun onExtendedColorsUpdated(extendedColors: List<ExtendedColor>) {
+        project.themeHolder.colorSchemeHolder.apply {
+            this.extendedColors.value = extendedColors
+        }
+        saveProject()
+    }
+
+    fun onAddNewExtendedColor(extendedColor: ExtendedColor) {
+        val extendedColors = project.themeHolder.colorSchemeHolder.extendedColors.value
+        if (extendedColor.name.isNotBlank()) {
+            val names = extendedColors.map { it.name }.toSet()
+            val name = generateUniqueName(extendedColor.name, names)
+            val newExtendedColor =
+                extendedColor.copy(
+                    name = name,
+                )
+            onExtendedColorsUpdated(extendedColors + newExtendedColor)
+        }
+    }
+
+    fun onChangeExtendedColor(
+        extendedColor: ExtendedColor,
+        newExtendedColor: ExtendedColor,
+    ) {
+        val extendedColors = project.themeHolder.colorSchemeHolder.extendedColors.value
+        onExtendedColorsUpdated(
+            extendedColors.map { if (it == extendedColor) newExtendedColor else it },
+        )
+    }
+
+    fun onRenameExtendedColor(
+        extendedColor: ExtendedColor,
+        newName: String,
+    ) {
+        val extendedColors = project.themeHolder.colorSchemeHolder.extendedColors.value
+        if (newName.isNotBlank()) {
+            val names = extendedColors.map { it.name }.toSet()
+            val name = generateUniqueName(newName, names)
+            onExtendedColorsUpdated(
+                extendedColors.map {
+                    if (it == extendedColor) {
+                        it.copy(name = name)
+                    } else {
+                        it
+                    }
+                },
+            )
+        }
+    }
+
+    fun onDeleteExtendedColor(extendedColor: ExtendedColor) {
+        val extendedColors = project.themeHolder.colorSchemeHolder.extendedColors.value
+        onExtendedColorsUpdated(
+            extendedColors.filter { it != extendedColor },
+        )
     }
 
     fun onColorResetToDefault() {
@@ -187,6 +246,7 @@ class ThemeEditorViewModel(
             paletteStyle = holder.paletteStyle
             lightColorScheme.value = holder.lightColorScheme.value
             darkColorScheme.value = holder.darkColorScheme.value
+            extendedColors.value = holder.extendedColors.value
         }
     }
 }


### PR DESCRIPTION
This PR adds support for **extended colors** in the theme editor.

- Edit extended colors
- Harmonize them against the source/primary color
- Rename extended colors
- Delete extended colors

## Notes
Currently, `ColorWrapper` only accepts `Material3ColorWrapper` and `Color`.  
In the future, it would be beneficial if `ColorWrapper` could also accept `ExtendedColor`.  
This would allow generating code for the created `ExtendedColor` variable instead of directly passing its color as a `Color` parameter.

<img width="1181" height="351" alt="image" src="https://github.com/user-attachments/assets/f036f1bb-3cda-45bd-92ac-ecf00c45c808" />
