### PR TITLE
Use KotlinPoet %S format specifier for string literals to properly escape characters

### DIFF
--- a/core/model/src/commonMain/kotlin/io/composeflow/kotlinpoet/Constants.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/kotlinpoet/Constants.kt
@@ -1,7 +1,0 @@
-package io.composeflow.kotlinpoet
-
-/**
- * Hard-coded value where KotlinPoet puts a line break if the length of a String value exceeds
- * this value.
- */
-const val KOTLINPOET_COLUMN_LIMIT = 100

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/apieditor/ApiProperty.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/apieditor/ApiProperty.kt
@@ -21,7 +21,7 @@ sealed interface ApiProperty {
     data class IntrinsicValue(
         val value: String = "",
     ) : ApiProperty {
-        override fun asCodeBlock(): CodeBlockWrapper = CodeBlockWrapper.of("\"\"\"$value\"\"\"")
+        override fun asCodeBlock(): CodeBlockWrapper = CodeBlockWrapper.of("%S", value)
 
         override fun asStringValue(): String = value
     }
@@ -45,7 +45,7 @@ sealed interface ApiProperty {
                 .builder(
                     name = name,
                     type = String::class.asTypeNameWrapper(),
-                ).defaultValue("\"$defaultValue\"")
+                ).defaultValue("%S", defaultValue)
                 .build()
     }
 }

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/datatype/FieldType.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/datatype/FieldType.kt
@@ -36,7 +36,7 @@ sealed interface FieldType<T> : DropdownItem {
 
         override fun defaultValue(): kotlin.String = defaultValue
 
-        override fun defaultValueAsCodeBlock(project: Project): CodeBlockWrapper = CodeBlockWrapper.of("\"${defaultValue}\"")
+        override fun defaultValueAsCodeBlock(project: Project): CodeBlockWrapper = CodeBlockWrapper.of("%S", defaultValue)
 
         @Composable
         override fun asDropdownText(): AnnotatedString = AnnotatedString("String")

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/datatype/FilterExpression.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/datatype/FilterExpression.kt
@@ -149,7 +149,7 @@ data class SingleFilter(
             is FilterFieldType.DataField -> {
                 project.findDataTypeOrNull(filterFieldType.dataTypeId)?.let {
                     it.findDataFieldOrNull(filterFieldType.dataFieldId)?.let { dataField ->
-                        builder.add("\"${dataField.variableName}\" ")
+                        builder.add("%S ", dataField.variableName)
                     }
                 }
             }

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/InstantWrapper.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/wrapper/InstantWrapper.kt
@@ -30,8 +30,9 @@ data class InstantWrapper(
             CodeBlockWrapper.of("%T.System.now()", Clock::class.asTypeNameWrapper())
         } else {
             CodeBlockWrapper.of(
-                "%T.parse(\"${asString()}\").%M(%T.UTC)",
+                "%T.parse(%S).%M(%T.UTC)",
                 LocalDate::class.asTypeNameWrapper(),
+                asString(),
                 MemberNameWrapper.get("kotlinx.datetime", "atStartOfDayIn", isExtension = true),
                 TimeZone::class.asTypeNameWrapper(),
             )

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/project/ParameterWrapper.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/project/ParameterWrapper.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.Modifier
 import io.composeflow.asVariableName
 import io.composeflow.editor.validator.FloatValidator
 import io.composeflow.editor.validator.IntValidator
-import io.composeflow.kotlinpoet.KOTLINPOET_COLUMN_LIMIT
 import io.composeflow.kotlinpoet.wrapper.CodeBlockWrapper
 import io.composeflow.kotlinpoet.wrapper.ParameterSpecWrapper
 import io.composeflow.model.parameter.lazylist.LazyListChildParams
@@ -52,18 +51,7 @@ sealed interface ParameterWrapper<T> {
         @Transient
         override val variableName: String = name.asVariableName()
 
-        override fun defaultValueAsCodeBlock(project: Project): CodeBlockWrapper =
-            if (defaultValue.contains("\n") ||
-                defaultValue.contains("\r") ||
-                defaultValue.length >= KOTLINPOET_COLUMN_LIMIT
-            ) {
-                // It looks like Kotlinpoet's column limit is hard-coded as 100.
-                // That means a string more than 100 characters can be translated as multiline
-                // string unintentionally.
-                CodeBlockWrapper.of("\"\"\"${defaultValue}\"\"\"")
-            } else {
-                CodeBlockWrapper.of("\"$defaultValue\"")
-            }
+        override fun defaultValueAsCodeBlock(project: Project): CodeBlockWrapper = CodeBlockWrapper.of("%S", defaultValue)
     }
 
     @Serializable

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/property/AssignableProperty.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/property/AssignableProperty.kt
@@ -28,7 +28,6 @@ import io.composeflow.editor.validator.ValidateResult
 import io.composeflow.kotlinpoet.ClassHolder
 import io.composeflow.kotlinpoet.GeneratedPlace
 import io.composeflow.kotlinpoet.GenerationContext
-import io.composeflow.kotlinpoet.KOTLINPOET_COLUMN_LIMIT
 import io.composeflow.kotlinpoet.MemberHolder
 import io.composeflow.kotlinpoet.wrapper.CodeBlockWrapper
 import io.composeflow.kotlinpoet.wrapper.MemberNameWrapper
@@ -389,15 +388,7 @@ sealed interface StringProperty : AssignableProperty {
 
         override fun displayText(project: Project): String = value
 
-        override fun asCodeBlock(): CodeBlockWrapper =
-            if (value.contains("\n") || value.contains("\r") || value.length >= KOTLINPOET_COLUMN_LIMIT) {
-                // It looks like Kotlinpoet's column limit is hard-coded as 100.
-                // That means a string more than 100 characters can be translated as multiline
-                // string unintentionally.
-                CodeBlockWrapper.of("\"\"\"%L\"\"\"", value)
-            } else {
-                CodeBlockWrapper.of("\"%L\"", value)
-            }
+        override fun asCodeBlock(): CodeBlockWrapper = CodeBlockWrapper.of("%S", value)
     }
 
     @Serializable

--- a/core/model/src/jvmTest/kotlin/io/composeflow/model/parameter/TextTraitTest.kt
+++ b/core/model/src/jvmTest/kotlin/io/composeflow/model/parameter/TextTraitTest.kt
@@ -257,7 +257,7 @@ class TextTraitTest {
                 dryRun = false,
             )
         val textStr =
-            "\"\"\"Great news! Your package has arrived safely and is now waiting for you at your doorstep. Please check it at your earliest convenience and let us know if everything is in order. Enjoy your purchase!\"\"\""
+            "\"Great news! Your package has arrived safely and is now waiting for you at your doorstep. Please check it at your earliest convenience and let us know if everything is in order. Enjoy your purchase!\""
         assertEquals(
             """
             androidx.compose.material3.Text(

--- a/feature/uibuilder/src/jvmTest/kotlin/io/composeflow/ui/uibuilder/AwtToolkitMock.kt
+++ b/feature/uibuilder/src/jvmTest/kotlin/io/composeflow/ui/uibuilder/AwtToolkitMock.kt
@@ -38,9 +38,14 @@ import java.awt.Toolkit
  *
  * @param screenResolution The desired screen resolution to be returned by the mocked Toolkit. Default is 96 DPI.
  */
-fun mockAwtToolkitForComposeResources(screenResolution: Int = 96) {
-    val toolkit = spyk(Toolkit.getDefaultToolkit())
-    every { toolkit.screenResolution } returns screenResolution
-    mockkStatic(Toolkit::class)
-    every { Toolkit.getDefaultToolkit() } returns toolkit
+fun mockAwtToolkitForComposeResourcesIfNecessary(screenResolution: Int = 96) {
+    val toolkit = Toolkit.getDefaultToolkit()
+    try {
+        toolkit.screenResolution
+    } catch (_: HeadlessException) {
+        val spied = spyk(Toolkit.getDefaultToolkit())
+        every { spied.screenResolution } returns screenResolution
+        mockkStatic(Toolkit::class)
+        every { Toolkit.getDefaultToolkit() } returns spied
+    }
 }

--- a/feature/uibuilder/src/jvmTest/kotlin/io/composeflow/ui/uibuilder/UiBuilderOperatorTest.kt
+++ b/feature/uibuilder/src/jvmTest/kotlin/io/composeflow/ui/uibuilder/UiBuilderOperatorTest.kt
@@ -35,7 +35,7 @@ class UiBuilderOperatorTest {
 
     @Before
     fun setUp() {
-        mockAwtToolkitForComposeResources()
+        mockAwtToolkitForComposeResourcesIfNecessary()
         uiBuilderOperator = UiBuilderOperator()
         project = Project()
         screen = project.screenHolder.screens.first()


### PR DESCRIPTION
Close #195.

If a string contains double-quotes and it's embedded in the genrated Kotlin code as a string literal, the code can't compile because the quote is not escaped.

```kotlin
// Before the fix
  public fun onSetStringLiterals() {
    viewModelScope.launch {
                    val updated = string_literalsFlow.value.copy(string_value = "B"B",
    )
                    flowSettings.putString("string_literals", jsonSerializer.encodeToString(updated))
                }
  }
```

If we use %S format specifier, such characters are escaped. Also, multiline strings are properly handled. Here is an example of generated code contains multi-line string literal.

```kotlin
  public fun onSetStringLiterals() {
    viewModelScope.launch {
                    val updated = string_literalsFlow.value.copy(string_value = """
    |first line
    |second line
    |third line
    """.trimMargin(),
    )
                    flowSettings.putString("string_literals", jsonSerializer.encodeToString(updated))
                }
  }
```

Also long strings are handled without any issues.

```kotlin
  public fun onSetStringLiterals() {
    viewModelScope.launch {
                    val updated = string_literalsFlow.value.copy(string_value = "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890",
    )
                    flowSettings.putString("string_literals", jsonSerializer.encodeToString(updated))
                }
  }
```