### PR TITLE
Add suspend function info to GenerationContext and avoid unnecessary coroutine launch

### DIFF
--- a/core/model/src/commonMain/kotlin/io/composeflow/kotlinpoet/GenerationContext.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/kotlinpoet/GenerationContext.kt
@@ -17,6 +17,7 @@ data class GenerationContext(
      */
     val componentCountMap: MutableMap<String, Int> = mutableMapOf(),
     val generatedPlace: GeneratedPlace = GeneratedPlace.Unspecified,
+    val withinSuspendedFunction: Boolean = false,
     val viewModelMap: MutableMap<String, ComposeEditableContext> = mutableMapOf(),
     val currentEditable: CanvasEditable = Screen(name = ""),
 ) {

--- a/core/model/src/commonMain/kotlin/io/composeflow/kotlinpoet/wrapper/CodeBlockWrapper.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/kotlinpoet/wrapper/CodeBlockWrapper.kt
@@ -61,9 +61,3 @@ expect class CodeBlockBuilderWrapper {
 
     fun endControlFlow(): CodeBlockBuilderWrapper
 }
-
-fun CodeBlockBuilderWrapper.controlFlow(
-    controlFlow: String,
-    vararg args: Any?,
-    block: (CodeBlockBuilderWrapper) -> CodeBlockBuilderWrapper,
-): CodeBlockBuilderWrapper = block(beginControlFlow(controlFlow, *args)).endControlFlow()

--- a/core/model/src/commonMain/kotlin/io/composeflow/kotlinpoet/wrapper/CodeBlockWrapperExtensions.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/kotlinpoet/wrapper/CodeBlockWrapperExtensions.kt
@@ -1,0 +1,110 @@
+package io.composeflow.kotlinpoet.wrapper
+
+import io.composeflow.kotlinpoet.GenerationContext
+import io.composeflow.kotlinpoet.MemberHolder
+
+/**
+ * Creates a control flow block with automatic begin/end handling.
+ *
+ * This is a convenience extension that wraps code in a control flow structure (e.g., if, while, for)
+ * and automatically calls [beginControlFlow] and [endControlFlow].
+ *
+ * @param controlFlow The control flow string (e.g., "if (%L)", "for (%L in %L)")
+ * @param args Format arguments to be interpolated into the control flow string
+ * @param block Lambda that receives the builder and adds code within the control flow
+ * @return This builder for chaining
+ *
+ * @sample
+ * ```kotlin
+ * builder.controlFlow("if (value > 0)") {
+ *     addStatement("println(\"Positive\")")
+ * }
+ * // Generates:
+ * // if (value > 0) {
+ * //     println("Positive")
+ * // }
+ * ```
+ */
+fun CodeBlockBuilderWrapper.controlFlow(
+    controlFlow: String,
+    vararg args: Any?,
+    block: (CodeBlockBuilderWrapper) -> CodeBlockBuilderWrapper,
+): CodeBlockBuilderWrapper = block(beginControlFlow(controlFlow, *args)).endControlFlow()
+
+/**
+ * Wraps code in a coroutine launch block.
+ *
+ * This extension always wraps the provided code in a `viewModelScope.launch { }` block,
+ * regardless of the execution context. For conditional launching based on suspend context,
+ * use [launchCoroutineIfNeeded] instead.
+ *
+ * @param controlFlow The control flow format string. Default: `"%M.%M {"`
+ * @param args Format arguments. Default: `[viewModelScope, launch]`
+ * @param block Lambda that adds code to execute within the coroutine
+ * @return This builder for chaining
+ *
+ * @see launchCoroutineIfNeeded for conditional launching
+ *
+ * @sample
+ * ```kotlin
+ * builder.launchCoroutine {
+ *     addStatement("performAsyncOperation()")
+ * }
+ * // Generates:
+ * // viewModelScope.launch {
+ * //     performAsyncOperation()
+ * // }
+ * ```
+ */
+fun CodeBlockBuilderWrapper.launchCoroutine(
+    controlFlow: String = "%M.%M",
+    vararg args: Any? = arrayOf(MemberHolder.PreCompose.viewModelScope, MemberHolder.Coroutines.launch),
+    block: (CodeBlockBuilderWrapper) -> CodeBlockBuilderWrapper,
+): CodeBlockBuilderWrapper = controlFlow(controlFlow, *args, block = block)
+
+/**
+ * Conditionally wraps code in a coroutine launch block based on execution context.
+ *
+ * This extension intelligently determines whether to wrap code in a `viewModelScope.launch { }` block:
+ * - If [GenerationContext.withinSuspendedFunction] is `true`: executes the block directly without launching
+ * - If [GenerationContext.withinSuspendedFunction] is `false`: wraps the block in a coroutine launch
+ *
+ * This prevents unnecessary nested coroutine launches when the code is already executing within
+ * a suspend function context, improving performance and avoiding redundant coroutine creation.
+ *
+ * @param context The generation context containing information about the current execution environment
+ * @param controlFlow The control flow format string. Default: `"%M.%M {"`
+ * @param args Format arguments. Default: `[viewModelScope, launch]`
+ * @param block Lambda that adds code to execute (with or without coroutine wrapping)
+ * @return This builder for chaining
+ *
+ * @sample
+ * ```kotlin
+ * // When NOT in a suspend function:
+ * builder.launchCoroutineIfNeeded(context) {
+ *     addStatement("settings.putString(\"key\", value)")
+ * }
+ * // Generates:
+ * // viewModelScope.launch {
+ * //     settings.putString("key", value)
+ * // }
+ *
+ * // When ALREADY in a suspend function:
+ * builder.launchCoroutineIfNeeded(context) {
+ *     addStatement("settings.putString(\"key\", value)")
+ * }
+ * // Generates:
+ * // settings.putString("key", value)
+ * ```
+ */
+fun CodeBlockBuilderWrapper.launchCoroutineIfNeeded(
+    context: GenerationContext,
+    controlFlow: String = "%M.%M",
+    vararg args: Any? = arrayOf(MemberHolder.PreCompose.viewModelScope, MemberHolder.Coroutines.launch),
+    block: (CodeBlockBuilderWrapper) -> CodeBlockBuilderWrapper,
+): CodeBlockBuilderWrapper =
+    if (context.withinSuspendedFunction) {
+        block(this)
+    } else {
+        controlFlow(controlFlow, *args, block = block)
+    }

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/action/StateOperation.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/action/StateOperation.kt
@@ -143,24 +143,12 @@ sealed interface StateOperation {
                 funSpecBuilder.addParameter(paramSpec)
             }
 
-            val wrapCodeBlock =
-                readProperty.generateWrapWithViewModelBlock(project, CodeBlockWrapper.of(""))
-            val updateStateCodeBlock =
-                writeState.generateUpdateStateCodeToViewModel(
-                    project,
-                    context,
-                    readProperty,
-                    dryRun = dryRun,
-                )
             context.addFunction(
                 funSpecBuilder
                     .addCode(
-                        wrapCodeBlock?.let {
-                            readProperty.generateWrapWithViewModelBlock(
-                                project,
-                                updateStateCodeBlock,
-                            )
-                        } ?: updateStateCodeBlock,
+                        readProperty.generateWrapWithViewModelBlock(project, context) { insideContext ->
+                            writeState.generateUpdateStateCodeToViewModel(project, insideContext, readProperty, dryRun = dryRun)
+                        },
                     ).build(),
                 dryRun = dryRun,
             )

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/property/AssignableProperty.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/property/AssignableProperty.kt
@@ -33,6 +33,7 @@ import io.composeflow.kotlinpoet.wrapper.CodeBlockWrapper
 import io.composeflow.kotlinpoet.wrapper.MemberNameWrapper
 import io.composeflow.kotlinpoet.wrapper.ParameterSpecWrapper
 import io.composeflow.kotlinpoet.wrapper.controlFlow
+import io.composeflow.kotlinpoet.wrapper.launchCoroutineIfNeeded
 import io.composeflow.model.apieditor.ApiId
 import io.composeflow.model.apieditor.isList
 import io.composeflow.model.datatype.DataFieldType
@@ -212,8 +213,9 @@ sealed interface AssignableProperty {
      */
     fun generateWrapWithViewModelBlock(
         project: Project,
-        insideContent: CodeBlockWrapper,
-    ): CodeBlockWrapper? = null
+        context: GenerationContext,
+        insideContent: (GenerationContext) -> CodeBlockWrapper,
+    ): CodeBlockWrapper = insideContent(context)
 
     /**
      * Generate CodeBlock that represents this property including the transformations by using
@@ -463,17 +465,12 @@ sealed interface StringProperty : AssignableProperty {
 
         override fun generateWrapWithViewModelBlock(
             project: Project,
-            insideContent: CodeBlockWrapper,
-        ): CodeBlockWrapper? {
-            // TODO Return null if the generated code is already in a suspend function.
-            //      https://github.com/ComposeFlow/ComposeFlow/issues/193
+            context: GenerationContext,
+            insideContent: (GenerationContext) -> CodeBlockWrapper,
+        ): CodeBlockWrapper {
             val builder = CodeBlockWrapper.builder()
-            builder.controlFlow(
-                "%M.%M {",
-                MemberHolder.PreCompose.viewModelScope,
-                MemberHolder.Coroutines.launch,
-            ) {
-                builder.add(insideContent)
+            builder.launchCoroutineIfNeeded(context) {
+                builder.add(insideContent(context.copy(withinSuspendedFunction = true)))
             }
             return builder.build()
         }
@@ -1737,7 +1734,8 @@ data class FirestoreCollectionProperty(
 
     override fun generateWrapWithViewModelBlock(
         project: Project,
-        insideContent: CodeBlockWrapper,
+        context: GenerationContext,
+        insideContent: (GenerationContext) -> CodeBlockWrapper,
     ): CodeBlockWrapper {
         val builder = CodeBlockWrapper.builder()
         val firestoreCollection =
@@ -1750,7 +1748,7 @@ when ($readVariableName) {
             """,
             ClassHolder.ComposeFlow.DataResult,
         )
-        builder.add(insideContent)
+        builder.add(insideContent(context))
         builder.add(
             """
     }
@@ -1869,7 +1867,8 @@ data class ApiResultProperty(
 
     override fun generateWrapWithViewModelBlock(
         project: Project,
-        insideContent: CodeBlockWrapper,
+        context: GenerationContext,
+        insideContent: (GenerationContext) -> CodeBlockWrapper,
     ): CodeBlockWrapper {
         val builder = CodeBlockWrapper.builder()
         val apiDefinition =
@@ -1882,7 +1881,7 @@ data class ApiResultProperty(
             """,
             ClassHolder.ComposeFlow.DataResult,
         )
-        builder.add(insideContent)
+        builder.add(insideContent(context))
         builder.add(
             """
         }


### PR DESCRIPTION
Close #193.

- Added `withinSuspendedFunction` property to `GenerationContext` to change the generated code based on whether it's already within a suspend function.
- Changed `insideContent` parameter of `AssignableProperty.generateWrapWithViewModelBlock()` to lambda to decide the inside content based on the context.
- Added `launchCoroutineIfNeeded` extension utility of `CodeBlockBuilderWrapper`.
- Updated generated code in `State.kt` to skip coroutine launch if it's already within a suspend function. Sorry for the large diff.

Here is an example of generated app code:

```kotlin
// Before the fix
  public fun onSetString_state() {
    viewModelScope.launch {
      viewModelScope.launch {
        flowSettings.putString("string_state", getString(Res.string.test))
      }
    }
  }

// After the fix
  public fun onSetString_state() {
    viewModelScope.launch {
      flowSettings.putString("string_state", getString(Res.string.test))
    }
  }
```