### PR TITLE
Change contentDescription from String to AssignableProperty with custom serializer

### DIFF
--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/AbstractIconTrait.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/AbstractIconTrait.kt
@@ -31,6 +31,7 @@ import io.composeflow.model.project.issue.Issue
 import io.composeflow.model.property.AssignableProperty
 import io.composeflow.model.property.ColorProperty
 import io.composeflow.model.property.PropertyContainer
+import io.composeflow.model.property.StringProperty
 import io.composeflow.model.type.ComposeFlowType
 import io.composeflow.serializer.FallbackEnumSerializer
 import io.composeflow.tooltip_icon_trait
@@ -58,7 +59,8 @@ abstract class AbstractIconTrait(
     @Transient
     open val blobInfoWrapper: BlobInfoWrapper? = null,
     @Transient
-    open val contentDescription: String = "Icon for ${imageVectorHolder?.name}",
+    open val contentDescription: AssignableProperty =
+        StringProperty.StringIntrinsicValue(value = "Icon for ${imageVectorHolder?.name}"),
     @Transient
     open val tint: AssignableProperty? =
         ColorProperty.ColorIntrinsicValue(
@@ -149,7 +151,7 @@ abstract class AbstractIconTrait(
                 imageVectorHolder?.let {
                     Icon(
                         imageVector = it.imageVector,
-                        contentDescription = contentDescription,
+                        contentDescription = contentDescription.valueExpression(project),
                         tint =
                             (tint as? ColorProperty.ColorIntrinsicValue)?.value?.getColor()
                                 ?: MaterialTheme.colorScheme.onBackground,
@@ -206,7 +208,16 @@ abstract class AbstractIconTrait(
                     codeBlockBuilder.add("imageVector = ")
                     codeBlockBuilder.add(holder.asCodeBlock())
                     codeBlockBuilder.addStatement(",")
-                    codeBlockBuilder.addStatement("""contentDescription = "$contentDescription",""")
+                    codeBlockBuilder.add("contentDescription = ")
+                    codeBlockBuilder.add(
+                        contentDescription.transformedCodeBlock(
+                            project,
+                            context,
+                            ComposeFlowType.StringType(),
+                            dryRun = dryRun,
+                        ),
+                    )
+                    codeBlockBuilder.addStatement(",")
                     tint?.let {
                         codeBlockBuilder.add("tint = ")
                         codeBlockBuilder.add(

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/FabTrait.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/FabTrait.kt
@@ -30,8 +30,10 @@ import io.composeflow.model.parameter.wrapper.Material3ColorWrapper
 import io.composeflow.model.project.Project
 import io.composeflow.model.project.appscreen.screen.composenode.ComposeNode
 import io.composeflow.model.property.AssignableProperty
+import io.composeflow.model.property.AssignablePropertyOrStringSerializer
 import io.composeflow.model.property.ColorProperty
 import io.composeflow.model.property.PropertyContainer
+import io.composeflow.model.property.StringProperty
 import io.composeflow.model.type.ComposeFlowType
 import io.composeflow.serializer.FallbackEnumSerializer
 import io.composeflow.tooltip_fab_trait
@@ -46,7 +48,9 @@ import org.jetbrains.compose.resources.StringResource
 @SerialName("FabTrait")
 data class FabTrait(
     val imageVectorHolder: ImageVectorHolder = Outlined.Add,
-    val contentDescription: String = "Floating Action Button for ${imageVectorHolder.name}",
+    @Serializable(AssignablePropertyOrStringSerializer::class)
+    val contentDescription: AssignableProperty =
+        StringProperty.StringIntrinsicValue(value = "Floating Action Button for ${imageVectorHolder.name}"),
     val fabPositionWrapper: FabPositionWrapper? = null,
     val containerColorWrapper: AssignableProperty? =
         ColorProperty.ColorIntrinsicValue(
@@ -138,7 +142,7 @@ data class FabTrait(
                 ) {
                     Icon(
                         imageVector = imageVectorHolder.imageVector,
-                        contentDescription = contentDescription,
+                        contentDescription = contentDescription.valueExpression(project),
                     )
                 }
             }
@@ -174,7 +178,7 @@ data class FabTrait(
                 ) {
                     Icon(
                         imageVector = imageVectorHolder.imageVector,
-                        contentDescription = contentDescription,
+                        contentDescription = contentDescription.valueExpression(project),
                     )
                 }
             }
@@ -210,7 +214,7 @@ data class FabTrait(
                 ) {
                     Icon(
                         imageVector = imageVectorHolder.imageVector,
-                        contentDescription = contentDescription,
+                        contentDescription = contentDescription.valueExpression(project),
                     )
                 }
             }
@@ -246,7 +250,7 @@ data class FabTrait(
                 ) {
                     Icon(
                         imageVector = imageVectorHolder.imageVector,
-                        contentDescription = contentDescription,
+                        contentDescription = contentDescription.valueExpression(project),
                     )
                 }
             }
@@ -319,7 +323,16 @@ data class FabTrait(
         codeBlockBuilder.addStatement("imageVector = ")
         codeBlockBuilder.add(imageVectorHolder.asCodeBlock())
         codeBlockBuilder.addStatement(",")
-        codeBlockBuilder.addStatement("""contentDescription = "$contentDescription",""")
+        codeBlockBuilder.add("contentDescription = ")
+        codeBlockBuilder.add(
+            contentDescription.transformedCodeBlock(
+                project,
+                context,
+                ComposeFlowType.StringType(),
+                dryRun = dryRun,
+            ),
+        )
+        codeBlockBuilder.addStatement(",")
         codeBlockBuilder.addStatement(")")
         codeBlockBuilder.addStatement("}")
         return codeBlockBuilder.build()

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/IconButtonTrait.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/IconButtonTrait.kt
@@ -18,7 +18,9 @@ import io.composeflow.model.parameter.wrapper.Material3ColorWrapper
 import io.composeflow.model.project.Project
 import io.composeflow.model.project.appscreen.screen.composenode.ComposeNode
 import io.composeflow.model.property.AssignableProperty
+import io.composeflow.model.property.AssignablePropertyOrStringSerializer
 import io.composeflow.model.property.ColorProperty
+import io.composeflow.model.property.StringProperty
 import io.composeflow.tooltip_icon_trait
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -38,7 +40,9 @@ data class IconButtonTrait(
     override val assetType: IconAssetType = IconAssetType.Material,
     override val imageVectorHolder: ImageVectorHolder? = Outlined.Add,
     override val blobInfoWrapper: BlobInfoWrapper? = null,
-    override val contentDescription: String = "Icon for ${imageVectorHolder?.name}",
+    @Serializable(AssignablePropertyOrStringSerializer::class)
+    override val contentDescription: AssignableProperty =
+        StringProperty.StringIntrinsicValue(value = "Icon for ${imageVectorHolder?.name}"),
     override val tint: AssignableProperty? =
         ColorProperty.ColorIntrinsicValue(
             value =

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/IconTrait.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/parameter/IconTrait.kt
@@ -18,7 +18,9 @@ import io.composeflow.model.parameter.wrapper.Material3ColorWrapper
 import io.composeflow.model.project.Project
 import io.composeflow.model.project.appscreen.screen.composenode.ComposeNode
 import io.composeflow.model.property.AssignableProperty
+import io.composeflow.model.property.AssignablePropertyOrStringSerializer
 import io.composeflow.model.property.ColorProperty
+import io.composeflow.model.property.StringProperty
 import io.composeflow.tooltip_icon_trait
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -30,7 +32,9 @@ data class IconTrait(
     override val assetType: IconAssetType = IconAssetType.Material,
     override val imageVectorHolder: ImageVectorHolder? = Outlined.Add,
     override val blobInfoWrapper: BlobInfoWrapper? = null,
-    override val contentDescription: String = "Icon for ${imageVectorHolder?.name}",
+    @Serializable(AssignablePropertyOrStringSerializer::class)
+    override val contentDescription: AssignableProperty =
+        StringProperty.StringIntrinsicValue(value = "Icon for ${imageVectorHolder?.name}"),
     override val tint: AssignableProperty? =
         ColorProperty.ColorIntrinsicValue(
             value =

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/property/AssignablePropertyOrStringSerializer.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/property/AssignablePropertyOrStringSerializer.kt
@@ -1,0 +1,60 @@
+package io.composeflow.model.property
+
+import com.charleskorn.kaml.YamlContentPolymorphicSerializer
+import com.charleskorn.kaml.YamlInput
+import com.charleskorn.kaml.YamlNode
+import com.charleskorn.kaml.YamlScalar
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * A custom serializer for AssignableProperty that handles two input formats:
+ * 1. Plain string values (deserialized as StringIntrinsicValue for backward compatibility)
+ * 2. Full AssignableProperty structures with type tags
+ *
+ * This serializer uses kaml's YamlContentPolymorphicSerializer for deserialization, which inspects
+ * the YAML node structure before deserialization to determine the appropriate deserialization strategy.
+ * A regular KSerializer cannot be used here because kaml tries to retrieve the type discriminator
+ * before deserialization begins, which would fail when encountering plain string values.
+ *
+ * For serialization, this serializer delegates to the standard AssignableProperty.serializer() to
+ * ensure that YAML tags are properly output according to the configured polymorphism style.
+ *
+ * When the input format is not YAML (e.g., JSON), this serializer falls back to using the default
+ * AssignableProperty serializer.
+ */
+object AssignablePropertyOrStringSerializer : YamlContentPolymorphicSerializer<AssignableProperty>(AssignableProperty::class) {
+    private val assignablePropertySerializer = AssignableProperty.serializer()
+
+    override fun deserialize(decoder: Decoder): AssignableProperty =
+        if (decoder is YamlInput) {
+            super.deserialize(decoder)
+        } else {
+            assignablePropertySerializer.deserialize(decoder)
+        }
+
+    override fun serialize(
+        encoder: Encoder,
+        value: AssignableProperty,
+    ) {
+        assignablePropertySerializer.serialize(encoder, value)
+    }
+
+    override fun selectDeserializer(node: YamlNode): DeserializationStrategy<AssignableProperty> =
+        if (node is YamlScalar) {
+            StringIntrinsicValueFromStringSerializer
+        } else {
+            AssignableProperty.serializer()
+        }
+}
+
+private object StringIntrinsicValueFromStringSerializer : DeserializationStrategy<AssignableProperty> {
+    override val descriptor = String.serializer().descriptor
+
+    override fun deserialize(decoder: Decoder): AssignableProperty {
+        val stringValue = decoder.decodeString()
+        return StringProperty.StringIntrinsicValue(value = stringValue)
+    }
+}

--- a/core/model/src/jvmTest/kotlin/io/composeflow/model/project/appscreen/screen/YamlExamples.kt
+++ b/core/model/src/jvmTest/kotlin/io/composeflow/model/project/appscreen/screen/YamlExamples.kt
@@ -530,9 +530,10 @@ topAppBarNode:
                     "OnLongClick": [ ]
             visibilityParams: { }
         -   id: "saveButton"
-            trait: !<IconTrait>
+            trait: !<IconButtonTrait>
                 imageVectorHolder: !<Outlined> "Check"
-                contentDescription: "Save changes"
+                contentDescription: !<StringIntrinsicValue>
+                    value: "Save changes"
                 tint: !<ColorIntrinsicValue>
                     value:
                         themeColor: "Primary"
@@ -564,7 +565,30 @@ topAppBarNode:
     visibilityParams: { }
 bottomAppBarNode: null
 navigationDrawerNode: null
-fabNode: null
+fabNode:
+    id: "addFab"
+    trait: !<FabTrait>
+        imageVectorHolder: !<Outlined> "Add"
+        contentDescription: "Add new item"
+        fabPositionWrapper: "End"
+    label: "Add FAB"
+    lazyListChildParams: !<FixedNumber>
+        numOfItems: 1
+    dynamicItems: null
+    actionHandler: !<ActionHandlerImpl>
+        actionsMap:
+            "OnClick":
+                - !<Simple>
+                    id: "addItemAction"
+                    action: !<ShowInformationDialog>
+                        id: "addItemDialog"
+                        title: !<StringIntrinsicValue>
+                            value: "Add Item"
+                        message: !<StringIntrinsicValue>
+                            value: "Create a new item"
+                        confirmText: !<StringIntrinsicValue>
+                            value: "Create"
+    visibilityParams: { }
 stateHolderImpl:
     states:
         - !<StringScreenState>

--- a/core/model/src/jvmTest/kotlin/io/composeflow/model/property/AssignablePropertyOrStringSerializerTest.kt
+++ b/core/model/src/jvmTest/kotlin/io/composeflow/model/property/AssignablePropertyOrStringSerializerTest.kt
@@ -1,0 +1,100 @@
+package io.composeflow.model.property
+
+import androidx.compose.runtime.mutableStateOf
+import io.composeflow.serializer.decodeFromStringWithFallback
+import io.composeflow.serializer.encodeToString
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AssignablePropertyOrStringSerializerTest {
+    @Test
+    fun testSerializationOutputsYamlTags() {
+        val original: AssignableProperty = StringProperty.StringIntrinsicValue(value = "Test Value")
+        val yaml = encodeToString(AssignablePropertyOrStringSerializer, original)
+
+        // Verify that the YAML contains a type tag (polymorphism marker)
+        assertTrue(
+            yaml.contains("!<StringIntrinsicValue>"),
+            "Serialized YAML should contain type tag. Actual YAML:\n$yaml",
+        )
+    }
+
+    @Test
+    fun testSerializationDeserializationRoundTrip() {
+        val original: AssignableProperty = StringProperty.StringIntrinsicValue(value = "Round Trip Value")
+        val yaml = encodeToString(AssignablePropertyOrStringSerializer, original)
+        val deserialized = decodeFromStringWithFallback(AssignablePropertyOrStringSerializer, yaml)
+
+        // Verify the deserialized object is correct
+        assertTrue(deserialized is StringProperty.StringIntrinsicValue, "Should deserialize to StringIntrinsicValue")
+        assertEquals("Round Trip Value", deserialized.value)
+    }
+
+    @Test
+    fun testBackwardCompatibility_plainStringDeserialization() {
+        // Test backward compatibility: plain string deserialization
+        val plainYaml = "Plain String Value"
+        val deserialized = decodeFromStringWithFallback(AssignablePropertyOrStringSerializer, plainYaml)
+
+        assertTrue(
+            deserialized is StringProperty.StringIntrinsicValue,
+            "Plain string should deserialize to StringIntrinsicValue",
+        )
+        assertEquals("Plain String Value", deserialized.value)
+    }
+
+    @Test
+    fun testSerializationWithComplexProperty() {
+        // Test with a more complex property containing transformers
+        val original: AssignableProperty =
+            StringProperty.StringIntrinsicValue(value = "Complex Value").apply {
+                propertyTransformers.add(FromString.ToString.AddBefore(mutableStateOf(StringProperty.StringIntrinsicValue("Prefix: "))))
+            }
+        val yaml = encodeToString(AssignablePropertyOrStringSerializer, original)
+
+        // Verify tag is present
+        assertTrue(yaml.contains("!<StringIntrinsicValue>"), "Should contain type tag for complex property")
+
+        // Deserialize and verify
+        val deserialized = decodeFromStringWithFallback(AssignablePropertyOrStringSerializer, yaml)
+        assertTrue(deserialized is StringProperty.StringIntrinsicValue)
+        assertEquals("Complex Value", deserialized.value)
+        assertEquals(1, deserialized.propertyTransformers.size)
+    }
+
+    @Test
+    fun testDeserializationWithYamlTag() {
+        val yamlWithTag =
+            """
+            !<StringIntrinsicValue>
+            value: "Tagged Value"
+            """.trimIndent()
+        val deserialized = decodeFromStringWithFallback(AssignablePropertyOrStringSerializer, yamlWithTag)
+
+        assertTrue(deserialized is StringProperty.StringIntrinsicValue)
+        assertEquals("Tagged Value", deserialized.value)
+    }
+
+    @Test
+    fun testSerializationOfDifferentPropertyTypes() {
+        val intProperty: AssignableProperty = IntProperty.IntIntrinsicValue(value = 42)
+        val boolProperty: AssignableProperty = BooleanProperty.BooleanIntrinsicValue(value = true)
+
+        val intYaml = encodeToString(AssignablePropertyOrStringSerializer, intProperty)
+        val boolYaml = encodeToString(AssignablePropertyOrStringSerializer, boolProperty)
+
+        assertTrue(intYaml.contains("!<IntIntrinsicValue>"), "Int property should have type tag")
+        assertTrue(boolYaml.contains("!<BooleanIntrinsicValue>"), "Boolean property should have type tag")
+
+        // Verify round trip
+        val intDeserialized = decodeFromStringWithFallback(AssignablePropertyOrStringSerializer, intYaml)
+        val boolDeserialized = decodeFromStringWithFallback(AssignablePropertyOrStringSerializer, boolYaml)
+
+        assertTrue(intDeserialized is IntProperty.IntIntrinsicValue)
+        assertEquals(42, intDeserialized.value)
+
+        assertTrue(boolDeserialized is BooleanProperty.BooleanIntrinsicValue)
+        assertEquals(true, boolDeserialized.value)
+    }
+}


### PR DESCRIPTION
Close #184.

Changes `contentDescription` property in icon-related traits from `String` to `AssignableProperty` to enable localizing the descriptions while maintaining backward compatibility with existing YAML files.