### PR TITLE
Return project issues as the call result for get_project_issues tool

### DIFF
--- a/core/model/src/commonMain/kotlin/io/composeflow/model/project/issue/Issue.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/project/issue/Issue.kt
@@ -45,6 +45,7 @@ sealed interface Issue {
     /**
      * Context where this issue is generated. E.g. Action
      */
+    @Serializable(IssueContextSerializer::class)
     val issueContext: Any?
 
     fun issueContextLabel(): String? =
@@ -59,12 +60,15 @@ sealed interface Issue {
     @Composable
     fun errorMessage(project: Project): String
 
+    @Serializable
+    @SerialName("ResolvedToUnknownType")
     data class ResolvedToUnknownType(
         val property: AssignableProperty,
         override val destination: NavigatableDestination =
             NavigatableDestination.UiBuilderScreen(
                 inspectorTabDestination = InspectorTabDestination.Inspector,
             ),
+        @Serializable(IssueContextSerializer::class)
         override val issueContext: Any? = null,
     ) : Issue {
         @Composable
@@ -75,6 +79,8 @@ sealed interface Issue {
                 )
     }
 
+    @Serializable
+    @SerialName("ResolvedToTypeNotAssignable")
     data class ResolvedToTypeNotAssignable(
         val property: AssignableProperty,
         val acceptableType: ComposeFlowType,
@@ -82,6 +88,7 @@ sealed interface Issue {
             NavigatableDestination.UiBuilderScreen(
                 inspectorTabDestination = InspectorTabDestination.Inspector,
             ),
+        @Serializable(IssueContextSerializer::class)
         override val issueContext: Any? = null,
     ) : Issue {
         @Composable
@@ -92,71 +99,92 @@ sealed interface Issue {
                 )
     }
 
+    @Serializable
+    @SerialName("InvalidScreenReference")
     data class InvalidScreenReference(
         val screenId: ScreenId,
         override val destination: NavigatableDestination =
             NavigatableDestination.UiBuilderScreen(
                 inspectorTabDestination = InspectorTabDestination.Inspector,
             ),
+        @Serializable(IssueContextSerializer::class)
         override val issueContext: Any? = null,
     ) : Issue {
         @Composable
         override fun errorMessage(project: Project): String = stringResource(Res.string.invalid_screen_reference)
     }
 
+    @Serializable
+    @SerialName("InvalidApiReference")
     data class InvalidApiReference(
         val apiId: ApiId,
         override val destination: NavigatableDestination =
             NavigatableDestination.UiBuilderScreen(
                 inspectorTabDestination = InspectorTabDestination.Inspector,
             ),
+        @Serializable(IssueContextSerializer::class)
         override val issueContext: Any? = null,
     ) : Issue {
         @Composable
         override fun errorMessage(project: Project): String = stringResource(Res.string.invalid_api_reference)
     }
 
+    @Serializable
+    @SerialName("InvalidAssetReference")
     data class InvalidAssetReference(
         override val destination: NavigatableDestination =
             NavigatableDestination.UiBuilderScreen(
                 inspectorTabDestination = InspectorTabDestination.Inspector,
             ),
+        @Serializable(IssueContextSerializer::class)
         override val issueContext: Any? = null,
     ) : Issue {
         @Composable
         override fun errorMessage(project: Project): String = stringResource(Res.string.invalid_asset_reference)
     }
 
+    @Serializable
+    @SerialName("InvalidResourceReference")
     data class InvalidResourceReference(
         val resourceType: String = "string",
         override val destination: NavigatableDestination =
             NavigatableDestination.UiBuilderScreen(
                 inspectorTabDestination = InspectorTabDestination.Inspector,
             ),
+        @Serializable(IssueContextSerializer::class)
         override val issueContext: Any? = null,
     ) : Issue {
         @Composable
         override fun errorMessage(project: Project): String = stringResource(Res.string.invalid_resource_reference, resourceType)
     }
 
+    @Serializable
+    @SerialName("InvalidApiParameterReference")
     data class InvalidApiParameterReference(
         override val destination: NavigatableDestination = NavigatableDestination.ApiEditorScreen,
+        @Serializable(IssueContextSerializer::class)
         override val issueContext: Any? = null,
     ) : Issue {
         @Composable
         override fun errorMessage(project: Project): String = stringResource(Res.string.invalid_api_parameter_reference)
     }
 
+    @Serializable
+    @SerialName("NavigationDrawerIsNotSet")
     data class NavigationDrawerIsNotSet(
         override val destination: NavigatableDestination = NavigatableDestination.UiBuilderScreen(),
+        @Serializable(IssueContextSerializer::class)
         override val issueContext: Any? = null,
     ) : Issue {
         @Composable
         override fun errorMessage(project: Project): String = stringResource(Res.string.invalid_api_parameter_reference)
     }
 
+    @Serializable
+    @SerialName("InvalidModifierRelation")
     data class InvalidModifierRelation(
         override val destination: NavigatableDestination = NavigatableDestination.UiBuilderScreen(),
+        @Serializable(IssueContextSerializer::class)
         override val issueContext: Any? = null,
     ) : Issue {
         @Composable

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/project/issue/IssueContextSerializer.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/project/issue/IssueContextSerializer.kt
@@ -39,6 +39,7 @@ object IssueContextSerializer : KSerializer<Any?> {
 
     override fun deserialize(decoder: Decoder): Any? =
         try {
+            // Deserialize as Action since it's the only known type for now. Extend as needed.
             decoder.decodeNullableSerializableValue(actionSerializer)
         } catch (_: Exception) {
             // If deserialization fails, return null

--- a/core/model/src/commonMain/kotlin/io/composeflow/model/project/issue/IssueContextSerializer.kt
+++ b/core/model/src/commonMain/kotlin/io/composeflow/model/project/issue/IssueContextSerializer.kt
@@ -1,0 +1,47 @@
+package io.composeflow.model.project.issue
+
+import io.composeflow.model.action.Action
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.serializer
+
+/**
+ * Custom serializer for issueContext that attempts to serialize the value if it's serializable,
+ * and skips it (uses null) otherwise.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+object IssueContextSerializer : KSerializer<Any?> {
+    private val actionSerializer = Action.serializer()
+
+    override val descriptor: SerialDescriptor = actionSerializer.descriptor
+
+    override fun serialize(
+        encoder: Encoder,
+        value: Any?,
+    ) {
+        when (value) {
+            null -> {
+                encoder.encodeNull()
+            }
+            is Action -> {
+                encoder.encodeSerializableValue(actionSerializer, value)
+            }
+            // Add more cases here for other known serializable types if needed
+            else -> {
+                // If we don't know how to serialize it, encode null
+                encoder.encodeNull()
+            }
+        }
+    }
+
+    override fun deserialize(decoder: Decoder): Any? =
+        try {
+            decoder.decodeNullableSerializableValue(actionSerializer)
+        } catch (_: Exception) {
+            // If deserialization fails, return null
+            null
+        }
+}

--- a/core/model/src/jvmTest/kotlin/io/composeflow/model/project/issue/IssueContextSerializerTest.kt
+++ b/core/model/src/jvmTest/kotlin/io/composeflow/model/project/issue/IssueContextSerializerTest.kt
@@ -1,0 +1,254 @@
+package io.composeflow.model.project.issue
+
+import io.composeflow.model.action.Navigation
+import io.composeflow.model.property.StringProperty
+import io.composeflow.serializer.decodeFromStringWithFallback
+import io.composeflow.serializer.encodeToString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class IssueContextSerializerTest {
+    @Test
+    fun testSerializeTrackableIssueWithNullContext() {
+        val issue =
+            Issue.InvalidScreenReference(
+                screenId = "screen-123",
+                issueContext = null,
+            )
+
+        val trackableIssue =
+            TrackableIssue(
+                destinationContext =
+                    DestinationContext.UiBuilderScreen(
+                        canvasEditableId = "canvas-1",
+                        composeNodeId = "node-1",
+                    ),
+                issue = issue,
+            )
+
+        val serialized = encodeToString(trackableIssue)
+        val deserialized = decodeFromStringWithFallback<TrackableIssue>(serialized)
+
+        assertTrue(deserialized.issue is Issue.InvalidScreenReference)
+        assertEquals("screen-123", deserialized.issue.screenId)
+        assertNull(deserialized.issue.issueContext)
+    }
+
+    @Test
+    fun testSerializeTrackableIssueWithActionContext() {
+        val action =
+            Navigation.NavigateTo(
+                id = "action-123",
+                screenId = "target-screen",
+            )
+
+        val issue =
+            Issue.InvalidScreenReference(
+                screenId = "screen-456",
+                issueContext = action,
+            )
+
+        val trackableIssue =
+            TrackableIssue(
+                destinationContext =
+                    DestinationContext.UiBuilderScreen(
+                        canvasEditableId = "canvas-1",
+                        composeNodeId = "node-1",
+                    ),
+                issue = issue,
+            )
+
+        val serialized = encodeToString(trackableIssue)
+        val deserialized = decodeFromStringWithFallback<TrackableIssue>(serialized)
+
+        assertTrue(deserialized.issue is Issue.InvalidScreenReference)
+        assertEquals("screen-456", deserialized.issue.screenId)
+
+        // issueContext should be deserialized as Action
+        assertTrue(deserialized.issue.issueContext is Navigation.NavigateTo)
+        assertEquals("action-123", deserialized.issue.issueContext.id)
+        assertEquals("target-screen", deserialized.issue.issueContext.screenId)
+    }
+
+    @Test
+    fun testSerializeMultipleIssueTypesWithinTrackableIssue() {
+        val destinationContext =
+            DestinationContext.UiBuilderScreen(
+                canvasEditableId = "canvas-1",
+                composeNodeId = "node-1",
+            )
+
+        // Test ResolvedToUnknownType
+        val issue1 =
+            TrackableIssue(
+                destinationContext = destinationContext,
+                issue =
+                    Issue.ResolvedToUnknownType(
+                        property = StringProperty.StringIntrinsicValue("test"),
+                        issueContext = null,
+                    ),
+            )
+        val serialized1 = encodeToString(issue1)
+        val deserialized1 = decodeFromStringWithFallback<TrackableIssue>(serialized1)
+        assertTrue(deserialized1.issue is Issue.ResolvedToUnknownType)
+        assertNull(deserialized1.issue.issueContext)
+
+        // Test InvalidApiReference
+        val issue2 =
+            TrackableIssue(
+                destinationContext = destinationContext,
+                issue =
+                    Issue.InvalidApiReference(
+                        apiId = "api-789",
+                        issueContext = null,
+                    ),
+            )
+        val serialized2 = encodeToString(issue2)
+        val deserialized2 = decodeFromStringWithFallback<TrackableIssue>(serialized2)
+        assertTrue(deserialized2.issue is Issue.InvalidApiReference)
+        assertEquals("api-789", deserialized2.issue.apiId)
+        assertNull(deserialized2.issue.issueContext)
+
+        // Test InvalidResourceReference
+        val issue3 =
+            TrackableIssue(
+                destinationContext = destinationContext,
+                issue =
+                    Issue.InvalidResourceReference(
+                        resourceType = "drawable",
+                        issueContext = null,
+                    ),
+            )
+        val serialized3 = encodeToString(issue3)
+        val deserialized3 = decodeFromStringWithFallback<TrackableIssue>(serialized3)
+        assertTrue(deserialized3.issue is Issue.InvalidResourceReference)
+        assertEquals("drawable", deserialized3.issue.resourceType)
+        assertNull(deserialized3.issue.issueContext)
+    }
+
+    @Test
+    fun testSerializeTrackableIssueWithMultipleFields() {
+        val action =
+            Navigation.NavigateTo(
+                id = "nav-action",
+                screenId = "destination",
+            )
+
+        val issue =
+            Issue.InvalidApiReference(
+                apiId = "api-missing",
+                issueContext = action,
+            )
+
+        val trackableIssue =
+            TrackableIssue(
+                destinationContext =
+                    DestinationContext.UiBuilderScreen(
+                        canvasEditableId = "screen-1",
+                        composeNodeId = "node-1",
+                    ),
+                issue = issue,
+            )
+
+        val serialized = encodeToString(trackableIssue)
+        val deserialized = decodeFromStringWithFallback<TrackableIssue>(serialized)
+
+        assertTrue(deserialized.destinationContext is DestinationContext.UiBuilderScreen)
+        assertTrue(deserialized.issue is Issue.InvalidApiReference)
+        assertEquals("api-missing", deserialized.issue.apiId)
+
+        // Verify issueContext was serialized and deserialized
+        val deserializedIssue = deserialized.issue
+        assertTrue(deserializedIssue.issueContext is Navigation.NavigateTo)
+        assertEquals("nav-action", deserializedIssue.issueContext.id)
+        assertEquals("destination", deserializedIssue.issueContext.screenId)
+    }
+
+    @Test
+    fun testAllIssueSubclassesAreSerializableWithinTrackableIssue() {
+        val action = Navigation.NavigateTo(id = "test-action", screenId = "test-screen")
+        val destinationContext =
+            DestinationContext.UiBuilderScreen(
+                canvasEditableId = "canvas-1",
+                composeNodeId = "node-1",
+            )
+
+        // Test all Issue subclasses can be serialized with Action context when wrapped in TrackableIssue
+        val trackableIssues =
+            listOf(
+                TrackableIssue(
+                    destinationContext = destinationContext,
+                    issue =
+                        Issue.ResolvedToUnknownType(
+                            property = StringProperty.StringIntrinsicValue("value"),
+                            issueContext = action,
+                        ),
+                ),
+                TrackableIssue(
+                    destinationContext = destinationContext,
+                    issue =
+                        Issue.InvalidScreenReference(
+                            screenId = "screen-1",
+                            issueContext = action,
+                        ),
+                ),
+                TrackableIssue(
+                    destinationContext = destinationContext,
+                    issue =
+                        Issue.InvalidApiReference(
+                            apiId = "api-1",
+                            issueContext = action,
+                        ),
+                ),
+                TrackableIssue(
+                    destinationContext = destinationContext,
+                    issue =
+                        Issue.InvalidAssetReference(
+                            issueContext = action,
+                        ),
+                ),
+                TrackableIssue(
+                    destinationContext = destinationContext,
+                    issue =
+                        Issue.InvalidResourceReference(
+                            resourceType = "string",
+                            issueContext = action,
+                        ),
+                ),
+                TrackableIssue(
+                    destinationContext = destinationContext,
+                    issue =
+                        Issue.InvalidApiParameterReference(
+                            issueContext = action,
+                        ),
+                ),
+                TrackableIssue(
+                    destinationContext = destinationContext,
+                    issue =
+                        Issue.NavigationDrawerIsNotSet(
+                            issueContext = action,
+                        ),
+                ),
+                TrackableIssue(
+                    destinationContext = destinationContext,
+                    issue =
+                        Issue.InvalidModifierRelation(
+                            issueContext = action,
+                        ),
+                ),
+            )
+
+        trackableIssues.forEach { trackableIssue ->
+            val serialized = encodeToString(trackableIssue)
+            val deserialized = decodeFromStringWithFallback<TrackableIssue>(serialized)
+
+            // Verify the trackable issue was deserialized correctly
+            assertEquals(trackableIssue.issue::class, deserialized.issue::class)
+            // Verify issueContext was deserialized
+            assertTrue(deserialized.issue.issueContext is Navigation.NavigateTo)
+            assertEquals("test-action", (deserialized.issue.issueContext as Navigation.NavigateTo).id)
+        }
+    }
+}

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ai/ToolDispatcher.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ai/ToolDispatcher.kt
@@ -336,7 +336,10 @@ class ToolDispatcher(
 
             is ToolArgs.GetProjectIssuesArgs -> {
                 val result = uiBuilderOperator.onGetProjectIssues(project)
-                if (result.errorMessages.isNotEmpty()) {
+                if (result.errorMessages.isEmpty()) {
+                    val issues = project.generateTrackableIssues()
+                    toolArgs.result = encodeToString(issues)
+                } else {
                     toolArgs.result = result.errorMessages.joinToString("; ")
                 }
                 result

--- a/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/uibuilder/UiBuilderOperator.kt
+++ b/feature/uibuilder/src/commonMain/kotlin/io/composeflow/ui/uibuilder/UiBuilderOperator.kt
@@ -548,7 +548,6 @@ class UiBuilderOperator {
         val result = EventResult()
         try {
             val issues = project.generateTrackableIssues()
-            result.issues.addAll(issues)
 
             Logger.i { "Found ${issues.size} project issues" }
             issues.forEach { trackableIssue ->
@@ -562,6 +561,8 @@ class UiBuilderOperator {
                     }
                 Logger.i { "Issue: $contextInfo - ${trackableIssue.issue::class.simpleName}" }
             }
+
+            // Success - no action needed, data will be stored in ToolArgs.result by ToolDispatcher
         } catch (e: Exception) {
             Logger.e(e) { "Error retrieving project issues" }
             result.errorMessages.add(getString(Res.string.error_retrieving_project_issues, e.message ?: "Unknown error"))


### PR DESCRIPTION
Close #202.

### Before

<img width="6016" height="3334" alt="CleanShot 2025-10-05 at 00 43 34@2x" src="https://github.com/user-attachments/assets/ce108f71-0f29-487f-a526-0f86e96a24c2" />

### After

<img width="6016" height="3334" alt="CleanShot 2025-10-05 at 00 42 23@2x" src="https://github.com/user-attachments/assets/69c83a26-0b8d-40d5-9a6a-981e6fca7dbc" />